### PR TITLE
Add `LLM::AuthError#response`

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -8,19 +8,24 @@ require_relative "llm/providers/gemini"
 module LLM
   class Error < StandardError; end
 
-  class AuthError < StandardError
+  class AuthError < Error
+    ##
+    # @return [Net::HTTPResponse]
+    #  Returns the response associated with an error
+    attr_accessor :response
+
     def initialize(msg = "Authentication Error")
       super
     end
   end
 
-  class NetError < StandardError
+  class NetError < Error
     def initialize(msg = "Network Error")
       super
     end
   end
 
-  class ParseError < StandardError
+  class ParseError < Error
     def initialize(msg = "Parsing Error")
       super
     end

--- a/lib/llm/http/client.rb
+++ b/lib/llm/http/client.rb
@@ -8,7 +8,9 @@ module LLM
       response.value
       response
     rescue Net::HTTPUnauthorized, Net::HTTPClientException
-      raise LLM::AuthError
+      error = LLM::AuthError.new("Authentication Error")
+      error.tap { _1.response = response }
+      raise error
     rescue SystemCallError
       raise LLM::NetError
     rescue JSON::ParserError

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe LLM::OpenAI do
       )
   end
 
-  before(:each, :auth_error) do
+  before(:each, :unauthorized) do
     stub_request(:post, "https://api.openai.com/v1/chat/completions")
       .with(headers: {"Content-Type" => "application/json"})
       .to_return(
@@ -61,7 +61,7 @@ RSpec.describe LLM::OpenAI do
       )
   end
 
-  it "Returns a successful completion", :success do
+  it "returns a successful completion", :success do
     expect(openai.complete("Hello!")).to be_a(LLM::Response).and have_attributes(
       messages: [
         have_attributes(
@@ -72,7 +72,15 @@ RSpec.describe LLM::OpenAI do
     )
   end
 
-  it "Returns an authentication error", :auth_error do
-    expect { openai.complete("Hello!") }.to raise_error(LLM::AuthError)
+  context "with an unauthorized error", :unauthorized do
+    it "raises an error" do
+      expect { openai.complete("Hello!") }.to raise_error(LLM::AuthError)
+    end
+
+    it "includes the response" do
+      openai.complete("Hello!")
+    rescue LLM::AuthError => ex
+      expect(ex.response).to be_kind_of(Net::HTTPResponse)
+    end
   end
 end


### PR DESCRIPTION
This new method provides access to the underlying HTTP response that is associated with an authorization error.