### PR TITLE
Add LLM::Error::RateLimit 

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -6,28 +6,28 @@ require_relative "llm/providers/anthropic"
 require_relative "llm/providers/gemini"
 
 module LLM
-  class Error < StandardError; end
+  ##
+  # The superclass of all LLM errors
+  class Error < RuntimeError
+    def initialize
+      block_given? ? yield(self) : nil
+    end
 
-  class AuthError < Error
     ##
-    # @return [Net::HTTPResponse]
-    #  Returns the response associated with an error
-    attr_accessor :response
-
-    def initialize(msg = "Authentication Error")
-      super
+    # The superclass of all HTTP protocol errors
+    class HTTPError < Error
+      ##
+      # @return [Net::HTTPResponse]
+      #  Returns the response associated with an error
+      attr_accessor :response
     end
-  end
 
-  class NetError < Error
-    def initialize(msg = "Network Error")
-      super
-    end
-  end
+    ##
+    # HTTPUnauthorized
+    Unauthorized = Class.new(HTTPError)
 
-  class ParseError < Error
-    def initialize(msg = "Parsing Error")
-      super
-    end
+    ##
+    # HTTPTooManyRequests
+    RateLimit = Class.new(HTTPError)
   end
 end

--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -8,19 +8,24 @@ require_relative "llm/providers/gemini"
 module LLM
   class Error < StandardError; end
 
-  class AuthError < StandardError
+  class AuthError < Error
+    ##
+    # @return [Net::HTTPResponse]
+    #  Returns the response associated with an error
+    attr_accessor :response
+
     def initialize(msg = "Authentication Error")
       super
     end
   end
 
-  class NetError < StandardError
+  class NetError < Error
     def initialize(msg = "Network Error")
       super
     end
   end
 
-  class ParseError < StandardError
+  class ParseError < Error
     def initialize(msg = "Parsing Error")
       super
     end

--- a/lib/llm/http/client.rb
+++ b/lib/llm/http/client.rb
@@ -8,7 +8,9 @@ module LLM
       response.value
       response
     rescue Net::HTTPUnauthorized, Net::HTTPClientException
-      raise LLM::AuthError
+      error = LLM::AuthError.new("Authentication Error")
+      error.tap { _1.response = response }
+      raise error
     rescue SystemCallError
       raise LLM::NetError
     rescue JSON::ParserError

--- a/spec/anthropic_spec.rb
+++ b/spec/anthropic_spec.rb
@@ -58,6 +58,6 @@ RSpec.describe LLM::Anthropic do
   end
 
   it "Returns an authentication error", :auth_error do
-    expect { anthropic.complete("Hello!") }.to raise_error(LLM::AuthError)
+    expect { anthropic.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/gemini_spec.rb
+++ b/spec/gemini_spec.rb
@@ -89,6 +89,6 @@ RSpec.describe LLM::Gemini do
   end
 
   it "Returns an authentication error", :auth_error do
-    expect { gemini.complete("Hello!") }.to raise_error(LLM::AuthError)
+    expect { gemini.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe LLM::OpenAI do
 
   context "with an unauthorized error", :unauthorized do
     it "raises an error" do
-      expect { openai.complete("Hello!") }.to raise_error(LLM::AuthError)
+      expect { openai.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
     end
 
     it "includes the response" do
       openai.complete("Hello!")
-    rescue LLM::AuthError => ex
+    rescue LLM::Error::Unauthorized => ex
       expect(ex.response).to be_kind_of(Net::HTTPResponse)
     end
   end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe LLM::OpenAI do
       )
   end
 
-  before(:each, :auth_error) do
+  before(:each, :unauthorized) do
     stub_request(:post, "https://api.openai.com/v1/chat/completions")
       .with(headers: {"Content-Type" => "application/json"})
       .to_return(
@@ -61,7 +61,7 @@ RSpec.describe LLM::OpenAI do
       )
   end
 
-  it "Returns a successful completion", :success do
+  it "returns a successful completion", :success do
     expect(openai.complete("Hello!")).to be_a(LLM::Response).and have_attributes(
       messages: [
         have_attributes(
@@ -72,7 +72,15 @@ RSpec.describe LLM::OpenAI do
     )
   end
 
-  it "Returns an authentication error", :auth_error do
-    expect { openai.complete("Hello!") }.to raise_error(LLM::AuthError)
+  context "with an unauthorized error", :unauthorized do
+    it "raises an error" do
+      expect { openai.complete("Hello!") }.to raise_error(LLM::AuthError)
+    end
+
+    it "includes the response" do
+      openai.complete("Hello!")
+    rescue LLM::AuthError => ex
+      expect(ex.response).to be_kind_of(Net::HTTPResponse)
+    end
   end
 end


### PR DESCRIPTION

Revisit the implementation of errors

**Summary**
* Add LLM::Error::RateLimit
* Add LLM::Error as the superclass of all LLM errors
* Add LLM::HTTPError as the superclass of all HTTP protocol errors
* Add `LLM::HTTPError#response`
* Remove LLM::AuthError, LLM::NetError, LLM::ParseError
