### PR TITLE
Allow multiple models with the Gemini provider

### DIFF
--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -9,14 +9,16 @@ module LLM
 
   class Gemini < Provider
     HOST = "generativelanguage.googleapis.com"
-    PATH = "/v1beta/models/gemini-1.5-flash"
+    PATH = "/v1beta/models"
 
     def initialize(secret)
       super(secret, HOST)
     end
 
     def complete(prompt, params = {})
-      req = Net::HTTP::Post.new [PATH, "generateContent"].join(":")
+      params = {model: "gemini-1.5-flash"}.merge(params)
+      path = [PATH, params[:model]].join("/")
+      req = Net::HTTP::Post.new [path, "generateContent"].join(":")
 
       body = {
         contents: [{parts: [{text: prompt}]}]


### PR DESCRIPTION
This change lets you choose from multiple models on Gemini, 
and the default remains the same: gemini-1.5-flash. 
Context: https://github.com/antaz/llm/pull/3#discussion_r1799812634