### PR TITLE
docs: update

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 module LLM
-  # The Provider class represents a base class for LLM (Language Model) providers.
+  ##
+  # The Provider class represents a base class for
+  # LLM (Language Model) providers
   class Provider
-    # Initializes a new Provider instance.
-    #
-    # @param secret [String] The secret key for authentication.
-    # @param host [String] The host address of the LLM provider.
-    # @param port [Integer] The port number (default: 443).
+    ##
+    # @param [String] secret
+    #  The secret key for authentication
+    # @param [String]
+    #  The host address of the LLM provider
+    # @param [Integer] port
+    #  The port number
     def initialize(secret, host, port = 443)
       @secret = secret
       @http = Net::HTTP.new(host, port).tap do |http|
@@ -16,20 +20,24 @@ module LLM
       end
     end
 
-    # Completes a given prompt using the LLM.
-    #
-    # @param prompt [String] The input prompt to be completed.
-    # @raise [NotImplementedError] This method must be implemented by subclasses.
+    ##
+    # Completes a given prompt using the LLM
+    # @param [String] prompt
+    #  The input prompt to be completed
+    # @raise [NotImplementedError]
+    #  When the method is not implemented by a subclass
     def complete(prompt)
       raise NotImplementedError
     end
 
     private
 
-    # Authenticates the given request.
-    #
-    # @param req [Net::HTTP::Request] The request to be authenticated.
-    # @raise [NotImplementedError] This method must be implemented by subclasses.
+    ##
+    # Prepares a request for authentication
+    # @param [Net::HTTP::Request] req
+    #  The request to prepare for authentication
+    # @raise [NotImplementedError]
+    #  (see LLM::Provider#complete)
     def auth(req)
       raise NotImplementedError
     end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -2,7 +2,7 @@
 
 module LLM
   ##
-  # The Provider class represents a base class for
+  # The Provider class represents an abstract class for
   # LLM (Language Model) providers
   class Provider
     ##


### PR DESCRIPTION
Summary

* Consistency: place the type as the first argument to `@param`
  ... Followed by the parameter name. In every other 
      place where there is a type, the type is the first 
      argument to `@param`. An example: `@return [String]`

* Consistent pattern of comments 
   In other places we use: `##\n# ...` 
   This change does the same for the new documentation. 
   We should at least be consistent, whatever pattern we use

* Avoid repetition
  With `@raise [NotImplementedError] (see <reference>`)

* Fix `Provider#auth`
   The documentation stated that it "authenticates a request". That's not quite true.
   It prepares the request for authentication.