### PR TITLE
Add `Response#raw`

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-require_relative "llm/version"
-
 module LLM
+  require_relative "llm/version"
+  require_relative "llm/error"
+  require_relative "llm/message"
+  require_relative "llm/response"
+  require_relative "llm/provider"
+
   module_function
 
   def anthropic(secret)
-    require_relative "llm/providers/anthropic" unless defined?(Anthropic)
+    require_relative "llm/providers/anthropic" unless defined?(LLM::Anthropic)
     LLM::Anthropic.new(secret)
   end
 

--- a/lib/llm/http_client.rb
+++ b/lib/llm/http_client.rb
@@ -2,20 +2,23 @@
 
 module LLM
   module HTTPClient
-    require "llm/error"
+    require "net/http"
     ##
-    # Makes an HTTP request and handles common error responses.
-    # @param http [Net::HTTP]
-    #   The HTTP object to use for the request.
-    # @param req [Net::HTTPRequest]
-    #   The request to send.
+    # Initiates a HTTP request
+    # @param [Net::HTTP] http
+    #  The HTTP object to use for the request
+    # @param [Net::HTTPRequest] req
+    #  The request to send
     # @return [Net::HTTPResponse]
-    #   The response from the server.
-    #
-    # @raise [LLM::Error::Unauthorized] If authentication fails.
-    # @raise [LLM::Error::RateLimit] If the rate limit is exceeded.
-    # @raise [LLM::Error::HTTPError] For other unexpected responses.
-    #
+    #  The response from the server
+    # @raise [LLM::Error::Unauthorized]
+    #  When authentication fails
+    # @raise [LLM::Error::RateLimit]
+    #  When the rate limit is exceeded
+    # @raise [LLM::Error::HTTPError]
+    #  When any other unsuccessful status code is returned
+    # @raise [SystemCallError]
+    #  When there is a network error at the operating system level
     def request(http, req)
       res = http.request(req)
       res.tap(&:value)

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -31,6 +31,15 @@ module LLM
       raise NotImplementedError
     end
 
+    ##
+    # @param [Hash] raw
+    #  A provider-specific Hash object
+    # @return [Array<LLM::Message>]
+    #  Returns an array of Message objects
+    def completion_messages(raw)
+      raise NotImplementedError
+    end
+
     private
 
     ##

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -31,6 +31,8 @@ module LLM
       raise NotImplementedError
     end
 
+    private
+
     ##
     # @param [Hash] raw
     #  A provider-specific Hash object
@@ -39,8 +41,6 @@ module LLM
     def completion_messages(raw)
       raise NotImplementedError
     end
-
-    private
 
     ##
     # Prepares a request for authentication

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -29,14 +29,14 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
+    private
+
     ##
     # @param (see LLM::Provider#completion_messages)
     # @return (see LLM::Provider#completion_messages)
     def completion_messages(raw)
       raw["content"].map { LLM::Message.new("assistant", _1["text"]) }
     end
-
-    private
 
     def auth(req)
       req["x-api-key"] = @secret

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module LLM
-  require "net/http"
-  require "json"
-  require "llm/provider"
-  require "llm/message"
-  require "llm/response"
-
   class Anthropic < Provider
     HOST = "api.anthropic.com"
     PATH = "/v1"
@@ -32,9 +26,14 @@ module LLM
       auth req
       res = request @http, req
 
-      Response.new(JSON.parse(res.body)["content"].map { |content|
-        Message.new("assistant", content.dig("text"))
-      })
+      Response::Completion.new(res.body, self)
+    end
+
+    ##
+    # @param (see LLM::Provider#completion_messages)
+    # @return (see LLM::Provider#completion_messages)
+    def completion_messages(raw)
+      raw["content"].map { LLM::Message.new("assistant", _1["text"]) }
     end
 
     private

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module LLM
-  require "net/http"
-  require "json"
-  require "llm/provider"
-  require "llm/message"
-
   class Gemini < Provider
     HOST = "generativelanguage.googleapis.com"
     PATH = "/v1beta/models"
@@ -28,11 +23,19 @@ module LLM
       auth req
       res = request @http, req
 
-      Response.new(
-        JSON.parse(res.body)["candidates"].map { |candidate|
-          Message.new(candidate.dig("content", "role"), candidate.dig("content", "parts", 0, "text"))
-        }
-      )
+      Response::Completion.new(res.body, self)
+    end
+
+    ##
+    # @param (see LLM::Provider#completion_messages)
+    # @return (see LLM::Provider#completion_messages)
+    def completion_messages(raw)
+      raw["candidates"].map do
+        LLM::Message.new(
+          _1.dig("content", "role"),
+          _1.dig("content", "parts", 0, "text")
+        )
+      end
     end
 
     private

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -26,6 +26,8 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
+    private
+
     ##
     # @param (see LLM::Provider#completion_messages)
     # @return (see LLM::Provider#completion_messages)
@@ -37,8 +39,6 @@ module LLM
         )
       end
     end
-
-    private
 
     def auth(req)
       req.path.replace [req.path, URI.encode_www_form(key: @secret)].join("?")

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module LLM
-  require "net/http"
-  require "json"
-  require "llm/provider"
-  require "llm/message"
-  require "llm/response"
-
   class OpenAI < Provider
     HOST = "api.openai.com"
     PATH = "/v1"
@@ -33,9 +27,16 @@ module LLM
       auth req
       res = request @http, req
 
-      Response.new(JSON.parse(res.body)["choices"].map { |choice|
-        Message.new(choice.dig("message", "role"), choice.dig("message", "content"))
-      })
+      Response::Completion.new(res.body, self)
+    end
+
+    ##
+    # @param (see LLM::Provider#completion_messages)
+    # @return (see LLM::Provider#completion_messages)
+    def completion_messages(raw)
+      raw["choices"].map do
+        LLM::Message.new(*_1["message"].values_at("role", "content"))
+      end
     end
 
     private

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -30,6 +30,8 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
+    private
+
     ##
     # @param (see LLM::Provider#completion_messages)
     # @return (see LLM::Provider#completion_messages)
@@ -38,8 +40,6 @@ module LLM
         LLM::Message.new(*_1["message"].values_at("role", "content"))
       end
     end
-
-    private
 
     def auth(req)
       req["Authorization"] = "Bearer #{@secret}"

--- a/lib/llm/response.rb
+++ b/lib/llm/response.rb
@@ -2,10 +2,20 @@
 
 module LLM
   class Response
-    attr_reader :messages
+    require "json"
+    require_relative "response/completion"
 
-    def initialize(messages)
-      @messages = messages
+    attr_reader :raw
+    attr_reader :provider
+
+    ##
+    # @param [String] raw
+    #  Response body
+    # @param [LLM::Provider] provider
+    #  A provider
+    def initialize(raw, provider)
+      @raw = JSON.parse(raw)
+      @provider = provider
     end
   end
 end

--- a/lib/llm/response.rb
+++ b/lib/llm/response.rb
@@ -5,7 +5,14 @@ module LLM
     require "json"
     require_relative "response/completion"
 
+    ##
+    # @return [Hash]
+    #  Returns the response body
     attr_reader :raw
+
+    ##
+    # @return [LLM::Provider]
+    #  Returns the provider
     attr_reader :provider
 
     ##

--- a/lib/llm/response/completion.rb
+++ b/lib/llm/response/completion.rb
@@ -6,7 +6,7 @@ module LLM
     # @return [Array<LLM::Message>]
     #  Returns an array of messages
     def messages
-      @provider.completion_messages(raw)
+      @provider.__send__ :completion_messages, raw
     end
   end
 end

--- a/lib/llm/response/completion.rb
+++ b/lib/llm/response/completion.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module LLM
+  class Response::Completion < Response
+    ##
+    # @return [Array<LLM::Message>]
+    #  Returns an array of messages
+    def messages
+      @provider.completion_messages(raw)
+    end
+  end
+end

--- a/spec/anthropic_spec.rb
+++ b/spec/anthropic_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe "LLM::Anthropic" do
       )
   end
 
-  it "Returns a successful completion", :success do
+  it "returns a successful completion", :success do
     response = anthropic.complete("Hello, world")
-    expect(response).to be_a(LLM::Response)
-    expect(response.messages.first).to have_attributes(
+    expect(response).to be_a(LLM::Response::Completion)
+    expect(response.messages[0]).to have_attributes(
       role: "assistant",
       content: "Hi! My name is Claude."
     )

--- a/spec/anthropic_spec.rb
+++ b/spec/anthropic_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "LLM::Anthropic" do
     )
   end
 
-  it "Returns an authentication error", :auth_error do
+  it "returns an authentication error", :auth_error do
     expect { anthropic.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/gemini_spec.rb
+++ b/spec/gemini_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "LLM::Gemini" do
     )
   end
 
-  it "Returns an authentication error", :auth_error do
+  it "returns an authentication error", :auth_error do
     expect { gemini.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/gemini_spec.rb
+++ b/spec/gemini_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe "LLM::Gemini" do
       )
   end
 
-  it "Returns a successful completion", :success do
-    response = gemini.complete("Hello, world")
-    expect(response).to be_a(LLM::Response)
-    expect(response.messages.first).to have_attributes(
+  it "returns a successful completion", :success do
+    completion = gemini.complete("Hello, world")
+    expect(completion).to be_a(LLM::Response::Completion)
+    expect(completion.messages.first).to have_attributes(
       role: "model",
       content: "Hello! How can I help you today? \n"
     )

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "LLM::OpenAI" do
   end
 
   it "returns a successful completion", :success do
-    expect(openai.complete("Hello!")).to be_a(LLM::Response).and have_attributes(
+    expect(openai.complete("Hello!")).to be_a(LLM::Response::Completion).and have_attributes(
       messages: [
         have_attributes(
           role: "assistant",


### PR DESCRIPTION
**Summary**

Fork of https://github.com/antaz/llm/pull/13

* Add `LLM::Response#raw` 
  The parsed response body from a LLM response
* Add `LLM::Response::Completion`
  Represents a response from a completion API.
  A subclass|type of `LLM::Response`. 
* Add `LLM::Completion#messages`
  Delegates to `@provider.completion_messages`
* Add `LLM::Provider#completion_messages`
  Returns an array of `LLM::Message` objects
  (After parsing a provider-specific data structure)
* Adjust require logic
  Our require logic was hard to follow and duplicated.
  Try to standardize a different approach