### PR TITLE
refactor: add LLM::Gemini::DEFAULT_PARAMS

### DIFF
--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -10,12 +10,16 @@ module LLM
     HOST = "generativelanguage.googleapis.com"
     PATH = "/v1beta/models"
 
+    DEFAULT_PARAMS = {
+      model: "gemini-1.5-flash"
+    }.freeze
+
     def initialize(secret)
       super(secret, HOST)
     end
 
     def complete(prompt, params = {})
-      params = {model: "gemini-1.5-flash"}.merge(params)
+      params = DEFAULT_PARAMS.merge(params)
       path = [PATH, params[:model]].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
 

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -20,7 +20,7 @@ module LLM
 
     def complete(prompt, params = {})
       params = DEFAULT_PARAMS.merge(params)
-      path = [PATH, params[:model]].join("/")
+      path = [PATH, params.delete(:model)].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
 
       body = {


### PR DESCRIPTION
Similar to how other providers are implemented,
this change introduces a 'DEFAULT_PARAMS' constant 
that provides a set of param defaults for the completion API