### PR TITLE
docs: fix typo

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -10,7 +10,7 @@ module LLM
     ##
     # @param [String] secret
     #  The secret key for authentication
-    # @param [String]
+    # @param [String] host
     #  The host address of the LLM provider
     # @param [Integer] port
     #  The port number


### PR DESCRIPTION
Fix warning:
```
$ bundle exec yardoc
[warn]: @param tag has unknown parameter name: The
    in file `lib/llm/provider.rb' near line 17
```