### PR TITLE
Introducing roles for completions and chat

### DIFF
--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -17,8 +17,8 @@ module LLM
     ##
     # @param prompt (see LLM::Provider#prompt)
     # @return [LLM::Conversation]
-    def chat(prompt, **params)
-      @provider.chat(prompt, **params.merge(messages: @thread))
+    def chat(prompt, role = :user, **params)
+      @provider.chat(prompt, role, **params.merge(messages: @thread))
     end
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -27,11 +27,11 @@ module LLM
     #  The input prompt to be completed
     # @raise [NotImplementedError]
     #  When the method is not implemented by a subclass
-    def complete(prompt, **params)
+    def complete(prompt, role = :user, **params)
       raise NotImplementedError
     end
 
-    def chat(prompt, **params)
+    def chat(prompt, role = :user, **params)
       raise NotImplementedError
     end
 

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -18,10 +18,10 @@ module LLM
       super(secret, HOST)
     end
 
-    def complete(prompt, **params)
+    def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new [PATH, "messages"].join("/")
       body = {
-        messages: ((params[:messages] || []) + [Message.new("user", prompt)]).map(&:to_h),
+        messages: ((params[:messages] || []) + [Message.new(role.to_s, prompt)]).map(&:to_h),
         **DEFAULT_PARAMS,
         **params
       }
@@ -34,9 +34,9 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
-    def chat(prompt, **params)
+    def chat(prompt, role = :user, **params)
       completion = complete(prompt, **params)
-      thread = [*params[:messages], Message.new("user", prompt), completion.choices.first]
+      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
       Conversation.new(self, thread)
     end
 

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -18,14 +18,14 @@ module LLM
       super(secret, HOST)
     end
 
-    def complete(prompt, **params)
+    def complete(prompt, role = :user, **params)
       params = DEFAULT_PARAMS.merge(params)
       path = [PATH, params.delete(:model)].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
 
       body = {
         contents: [{
-          parts: ((params[:messages] || []) + [Message.new("user", prompt)])
+          parts: ((params[:messages] || []) + [Message.new(role.to_s, prompt)])
             .map { |m| {text: m.content} }
         }]
       }
@@ -38,9 +38,9 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
-    def chat(prompt, **params)
+    def chat(prompt, role = :user, **params)
       completion = complete(prompt, **params)
-      thread = [*params[:messages], Message.new("user", prompt), completion.choices.first]
+      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
       Conversation.new(self, thread)
     end
 

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -18,11 +18,11 @@ module LLM
       super(secret, HOST)
     end
 
-    def complete(prompt, **params)
+    def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new [PATH, "chat", "completions"].join("/")
 
       body = {
-        messages: ((params[:messages] || []) + [Message.new("user", prompt)]).map(&:to_h),
+        messages: ((params[:messages] || []) + [Message.new(role.to_s, prompt)]).map(&:to_h),
         **DEFAULT_PARAMS,
         **params.except(:messages)
       }
@@ -36,9 +36,9 @@ module LLM
       Response::Completion.new(res.body, self)
     end
 
-    def chat(prompt, **params)
-      completion = complete(prompt, **params)
-      thread = [*params[:messages], Message.new("user", prompt), completion.choices.first]
+    def chat(prompt, role = :user, **params)
+      completion = complete(prompt, role, **params)
+      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
       Conversation.new(self, thread)
     end
 


### PR DESCRIPTION
This allows for passing the role to completion models, removing the dependency on the hardcoded "user" role
e.g:

`LLM.openai(OPENAI_KEY).chat "Be a helpful assitant", :system`
`LLM.openai(OPENAI_KEY).chat "Good Morning!", :user`