### PR TITLE
Track token usage for `Completion`

### DIFF
--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -56,6 +56,14 @@ module LLM
       raw["content"].map { LLM::Message.new("assistant", _1["text"]) }
     end
 
+    def completion_prompt_tokens(raw)
+      raw.dig("usage", "input_tokens")
+    end
+
+    def completion_completion_tokens(raw)
+      raw.dig("usage", "output_tokens")
+    end
+
     def auth(req)
       req["x-api-key"] = @secret
     end

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -65,6 +65,18 @@ module LLM
       end
     end
 
+    def completion_prompt_tokens(raw)
+      raw.dig("usageMetadata", "promptTokenCount")
+    end
+
+    def completion_completion_tokens(raw)
+      raw.dig("usageMetadata", "candidatesTokenCount")
+    end
+
+    def completion_total_tokens(raw)
+      raw.dig("usageMetadata", "totalTokenCount")
+    end
+
     def auth(req)
       req.path.replace [req.path, URI.encode_www_form(key: @secret)].join("?")
     end

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -60,6 +60,18 @@ module LLM
       end
     end
 
+    def completion_prompt_tokens(raw)
+      raw.dig("usage", "prompt_tokens")
+    end
+
+    def completion_completion_tokens(raw)
+      raw.dig("usage", "completion_tokens")
+    end
+
+    def completion_total_tokens(raw)
+      raw.dig("usage", "total_tokens")
+    end
+
     def auth(req)
       req["Authorization"] = "Bearer #{@secret}"
     end

--- a/lib/llm/response/completion.rb
+++ b/lib/llm/response/completion.rb
@@ -34,7 +34,9 @@ module LLM
     # @return [Integer]
     #   Returns the total count of tokens
     def total_tokens
-      @provider.__send__ :completion_total_tokens, raw
+      @provider.respond_to?(:completion_total_tokens) ?
+        @provider.__send__(:completion_total_tokens, raw) :
+        prompt_tokens + completion_tokens
     end
   end
 end

--- a/lib/llm/response/completion.rb
+++ b/lib/llm/response/completion.rb
@@ -15,5 +15,26 @@ module LLM
     def choices
       @provider.__send__ :completion_choices, raw
     end
+
+    ##
+    # @return [Integer]
+    #   Returns the count of prompt tokens
+    def prompt_tokens
+      @provider.__send__ :completion_prompt_tokens, raw
+    end
+
+    ##
+    # @return [Integer]
+    #   Returns the count of completion tokens
+    def completion_tokens
+      @provider.__send__ :completion_completion_tokens, raw
+    end
+
+    ##
+    # @return [Integer]
+    #   Returns the total count of tokens
+    def total_tokens
+      @provider.__send__ :completion_total_tokens, raw
+    end
   end
 end

--- a/spec/anthropic_spec.rb
+++ b/spec/anthropic_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe "LLM::Anthropic" do
         ]
       )
     end
+
+    it "has prompt_tokens" do
+      expect(completion.prompt_tokens).to eq(2095)
+    end
+
+    it "has completion_tokens" do
+      expect(completion.completion_tokens).to eq(503)
+    end
+
+    it "has total_tokens" do
+      expect(completion.total_tokens).to eq(2095 + 503)
+    end
   end
 
   it "returns an authentication error", :auth_error do

--- a/spec/gemini_spec.rb
+++ b/spec/gemini_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "LLM::Gemini" do
     let(:completion) { gemini.complete("Hello!") }
 
     it "has model" do
-      expect(completion).to have_attributes(model: "gemini-1.5-flash-001")
+      expect(completion.model).to eq("gemini-1.5-flash-001")
     end
 
     it "has choices" do
@@ -96,6 +96,18 @@ RSpec.describe "LLM::Gemini" do
           )
         ]
       )
+    end
+
+    it "has prompt_tokens" do
+      expect(completion.prompt_tokens).to eq(2)
+    end
+
+    it "has completion_tokens" do
+      expect(completion.completion_tokens).to eq(10)
+    end
+
+    it "has total_tokens" do
+      expect(completion.total_tokens).to eq(12)
     end
   end
 

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "LLM::OpenAI" do
     let(:completion) { openai.complete("Hello!") }
 
     it "has model" do
-      expect(completion).to have_attributes(model: "gpt-4o-mini-2024-07-18")
+      expect(completion.model).to eq("gpt-4o-mini-2024-07-18")
     end
 
     it "has choices" do
@@ -77,6 +77,18 @@ RSpec.describe "LLM::OpenAI" do
           )
         ]
       )
+    end
+
+    it "has prompt_tokens" do
+      expect(completion.prompt_tokens).to eq(9)
+    end
+
+    it "has completion_tokens" do
+      expect(completion.completion_tokens).to eq(9)
+    end
+
+    it "has total_tokens" do
+      expect(completion.total_tokens).to eq(18)
     end
   end
 


### PR DESCRIPTION
# Token Usage Tracking Methods

Added token tracking methods to `Completion` class:
* `#prompt_tokens`
* `#completion_tokens`
* `#total_tokens`

## Supported Providers
- [x] OpenAI
- [x] Anthropic
- [x] Gemini