### PR TITLE
Add LLM::LazyConversation

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -7,6 +7,8 @@ module LLM
   require_relative "llm/response"
   require_relative "llm/provider"
   require_relative "llm/conversation"
+  require_relative "llm/lazy_conversation"
+  require_relative "llm/lazy_thread"
 
   module_function
 

--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 module LLM
+  ##
+  # {LLM::Conversation LLM::Conversation} provides a conversation
+  # object that maintains a thread of messages that act as the
+  # context of the conversation.
+  #
+  # @example
+  #   llm = LLM.openai(key)
+  #   bot = llm.chat("What is the capital of France?")
+  #   bot.chat("What should we eat in Paris?")
+  #   bot.chat("What is the weather like in Paris?")
+  #   p bot.thread.map { [_1.role, _1.content] }
   class Conversation
     attr_reader :thread
 
@@ -18,7 +29,12 @@ module LLM
     # @param prompt (see LLM::Provider#prompt)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      @provider.chat(prompt, role, **params.merge(messages: @thread))
+      tap do
+        bot = @provider.chat(prompt, role, **params.merge(messages: @thread))
+        # The last two elements of the thread include the
+        # last input prompt, and the response from the LLM
+        @thread.concat(bot.thread[-2..-1])
+      end
     end
   end
 end

--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -33,7 +33,7 @@ module LLM
         bot = @provider.chat(prompt, role, **params.merge(messages: @thread))
         # The last two elements of the thread include the
         # last input prompt, and the response from the LLM
-        @thread.concat(bot.thread[-2..-1])
+        @thread.concat(bot.thread[-2..])
       end
     end
   end

--- a/lib/llm/lazy_conversation.rb
+++ b/lib/llm/lazy_conversation.rb
@@ -1,0 +1,35 @@
+module LLM
+  ##
+  # {LLM::LazyConversation LLM::LazyConversation} provides a
+  # conversation object that allows input prompts to be stacked
+  # and only sent to the LLM when a response is needed.
+  #
+  # @example
+  #   llm = LLM.openai(key)
+  #   bot = llm.chat!("What is the capital of France?")
+  #   bot.chat("What should we eat in Paris?")
+  #   bot.chat("What is the weather like in Paris?")
+  #   bot.thread.each do |message|
+  #     # A single request is made at this point
+  #   end
+  class LazyConversation
+    ##
+    # @return [LLM::LazyThread]
+    attr_reader :thread
+
+    ##
+    # @param [LLM::Provider] provider
+    #  A provider
+    def initialize(provider)
+      @provider = provider
+      @thread = LLM::LazyThread.new(provider)
+    end
+
+    ##
+    # @param prompt (see LLM::Provider#prompt)
+    # @return [LLM::Conversation]
+    def chat(prompt, role = :user, **params)
+      tap { @thread << [prompt, role, params] }
+    end
+  end
+end

--- a/lib/llm/lazy_thread.rb
+++ b/lib/llm/lazy_thread.rb
@@ -33,9 +33,9 @@ module LLM
 
     def complete!
       prompt, role, params = @thread[-1]
-      rest = @thread[0..-2].map { Array === _1 ? LLM::Message.new(_1[1], _1[0]) : _1 }
+      rest = @thread[0..-2].map { (Array === _1) ? LLM::Message.new(_1[1], _1[0]) : _1 }
       comp = @provider.complete(prompt, role, **params.merge(messages: rest)).choices.last
-      [ *rest, LLM::Message.new(role, prompt), comp ]
+      [*rest, LLM::Message.new(role, prompt), comp]
     end
   end
 end

--- a/lib/llm/lazy_thread.rb
+++ b/lib/llm/lazy_thread.rb
@@ -1,0 +1,41 @@
+module LLM
+  class LazyThread
+    include Enumerable
+
+    ##
+    # @param [LLM::Provider] provider
+    # @return [LLM::LazyThread]
+    def initialize(provider)
+      @provider = provider
+      @thread = []
+    end
+
+    ##
+    # @yield [LLM::Message]
+    #  Yields each message in the conversation thread
+    # @raise (see LLM::Provider#complete)
+    # @return [void]
+    def each
+      @thread = complete! unless @thread.grep(LLM::Message).size == @thread.size
+      @thread.each { yield(_1) }
+    end
+
+    ##
+    # @param message [Object]
+    #  A message to add to the conversation thread
+    # @return [void]
+    def <<(message)
+      @thread << message
+    end
+    alias_method :push, :<<
+
+    private
+
+    def complete!
+      prompt, role, params = @thread[-1]
+      rest = @thread[0..-2].map { Array === _1 ? LLM::Message.new(_1[1], _1[0]) : _1 }
+      comp = @provider.complete(prompt, role, **params.merge(messages: rest)).choices.last
+      [ *rest, LLM::Message.new(role, prompt), comp ]
+    end
+  end
+end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -35,6 +35,7 @@ module LLM
     end
 
     ##
+    # Starts a new conversation
     # @param prompt (see LLM::Provider#complete)
     # @param role (see LLM::Provider#complete)
     # @raise (see LLM::Provider#complete)

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -43,6 +43,16 @@ module LLM
       raise NotImplementedError
     end
 
+    ##
+    # Starts a lazy conversation
+    # @param prompt (see LLM::Provider#complete)
+    # @param role (see LLM::Provider#complete)
+    # @raise (see LLM::Provider#complete)
+    # @return [LLM::LazyResponse]
+    def chat!(prompt, role = :user, **params)
+      LazyConversation.new(self).chat(prompt, role, **params)
+    end
+
     private
 
     ##


### PR DESCRIPTION
`LLM::LazyConversation` provides a conversation object 
that allows input prompts to be stacked and only sent to 
the LLM when a response is needed.

```ruby
llm = LLM.openai(key)
bot = llm.chat! "Be a helpful assistant", :system
bot.chat "Help me find a place to eat"
bot.chat "Any type of cuisine will do"
bot.thread.each do |message|
  # At this point we send one request with all prompts
end
# Continue lazy conversation 
bot.chat "..."
```