### PR TITLE
Remove duplicate definitions of 'chat'

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -40,7 +40,9 @@ module LLM
     # @raise (see LLM::Provider#complete)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      raise NotImplementedError
+      completion = complete(prompt, role, **params)
+      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
+      Conversation.new(self, thread)
     end
 
     private

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -51,12 +51,6 @@ module LLM
       Response::Completion.new(res.body, self).extend(response_parser)
     end
 
-    def chat(prompt, role = :user, **params)
-      completion = complete(prompt, **params)
-      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
-      Conversation.new(self, thread)
-    end
-
     private
 
     def auth(req)

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -57,12 +57,6 @@ module LLM
       Response::Completion.new(res.body, self).extend(response_parser)
     end
 
-    def chat(prompt, role = :user, **params)
-      completion = complete(prompt, **params)
-      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
-      Conversation.new(self, thread)
-    end
-
     private
 
     def auth(req)

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -55,12 +55,6 @@ module LLM
       Response::Completion.new(res.body, self).extend(response_parser)
     end
 
-    def chat(prompt, role = :user, **params)
-      completion = complete(prompt, role, **params)
-      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
-      Conversation.new(self, thread)
-    end
-
     private
 
     def auth(req)


### PR DESCRIPTION
The 'chat' method was duplicated across providers. 
It can be implemented just once in the abstract Provider class instead