### PR TITLE
Support for `image_url`

### DIFF
--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -10,7 +10,13 @@ module LLM
     end
 
     def to_h
-      {role:, content:}
+      h = {role:}
+      if URI === @content
+        h.merge!({type: :image_url, content: @content.to_s})
+      else
+        h.merge!({type: :text, content: @content.to_s})
+      end
+      h
     end
   end
 end


### PR DESCRIPTION
This allows images to be passed to chat completions via URI e.g:
```ruby
openai(KEY).chat URI("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg")
```