### PR TITLE
refactor: change the signature of `Provider#complete`

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -41,7 +41,7 @@ module LLM
     # @raise (see LLM::Provider#complete)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      completion = complete(prompt, role, **params)
+      completion = complete(Message.new(role, prompt), **params)
       thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
       Conversation.new(self, thread)
     end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -8,7 +8,6 @@ module LLM
     require_relative "anthropic/response_parser"
 
     HOST = "api.anthropic.com"
-    PATH = "/v1"
     DEFAULT_PARAMS = {model: "claude-3-5-sonnet-20240620"}.freeze
 
     ##
@@ -26,7 +25,7 @@ module LLM
     end
 
     def complete(message, **params)
-      req = Net::HTTP::Post.new [PATH, "messages"].join("/")
+      req = Net::HTTP::Post.new ["/v1", "messages"].join("/")
       messages = [*(params.delete(:messages) || []), message]
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -25,9 +25,9 @@ module LLM
       Response::Embedding.new(res.body, self)
     end
 
-    def complete(prompt, role = :user, **params)
+    def complete(message, **params)
       req = Net::HTTP::Post.new [PATH, "messages"].join("/")
-      messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]
+      messages = [*(params.delete(:messages) || []), message]
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)
       req = preflight(req, body)

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -8,7 +8,6 @@ module LLM
     require_relative "gemini/response_parser"
 
     HOST = "generativelanguage.googleapis.com"
-    PATH = "/v1beta/models"
     DEFAULT_PARAMS = {model: "gemini-1.5-flash"}.freeze
 
     ##
@@ -18,7 +17,7 @@ module LLM
     end
 
     def embed(input, **params)
-      path = [PATH, "text-embedding-004"].join("/")
+      path = ["/v1beta/models", "text-embedding-004"].join("/")
       req = Net::HTTP::Post.new [path, "embedContent"].join(":")
       body = {content: {parts: [{text: input}]}}
       req = preflight(req, body)
@@ -28,7 +27,7 @@ module LLM
 
     def complete(message, **params)
       params = DEFAULT_PARAMS.merge(params)
-      path = [PATH, params.delete(:model)].join("/")
+      path = ["/v1beta/models", params.delete(:model)].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
       messages = [*(params.delete(:messages) || []), message]
       body = {

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -26,11 +26,11 @@ module LLM
       Response::Embedding.new(res.body, self)
     end
 
-    def complete(prompt, role = :user, **params)
+    def complete(message, **params)
       params = DEFAULT_PARAMS.merge(params)
       path = [PATH, params.delete(:model)].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
-      messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]
+      messages = [*(params.delete(:messages) || []), message]
       body = {
         contents: [{
           parts: messages.map { |m| {text: m.content} }

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -25,9 +25,9 @@ module LLM
       Response::Embedding.new(res.body, self)
     end
 
-    def complete(prompt, role = :user, **params)
+    def complete(message, **params)
       req = Net::HTTP::Post.new [PATH, "chat", "completions"].join("/")
-      messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]
+      messages = [*(params.delete(:messages) || []), message]
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)
       req = preflight(req, body)

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -8,7 +8,6 @@ module LLM
     require_relative "openai/response_parser"
 
     HOST = "api.openai.com"
-    PATH = "/v1"
     DEFAULT_PARAMS = {model: "gpt-4o-mini"}.freeze
 
     ##
@@ -18,7 +17,7 @@ module LLM
     end
 
     def embed(input, **params)
-      req = Net::HTTP::Post.new [PATH, "embeddings"].join("/")
+      req = Net::HTTP::Post.new ["/v1", "embeddings"].join("/")
       body = {input:, model: "text-embedding-3-small"}.merge!(params)
       req = preflight(req, body)
       res = request @http, req
@@ -26,7 +25,7 @@ module LLM
     end
 
     def complete(message, **params)
-      req = Net::HTTP::Post.new [PATH, "chat", "completions"].join("/")
+      req = Net::HTTP::Post.new ["/v1", "chat", "completions"].join("/")
       messages = [*(params.delete(:messages) || []), message]
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)

--- a/spec/anthropic_spec.rb
+++ b/spec/anthropic_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "LLM::Anthropic" do
   end
 
   context "with successful completion", :success do
-    let(:completion) { anthropic.complete("Hello, world") }
+    let(:completion) { anthropic.complete(LLM::Message.new("user", "Hello, world")) }
 
     it "has model" do
       expect(completion).to have_attributes(model: "claude-3-5-sonnet-20240620")
@@ -80,6 +80,6 @@ RSpec.describe "LLM::Anthropic" do
   end
 
   it "returns an authentication error", :auth_error do
-    expect { anthropic.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
+    expect { anthropic.complete(LLM::Message.new("user", "Hello!")) }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/gemini_spec.rb
+++ b/spec/gemini_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "LLM::Gemini" do
   end
 
   context "with successful completion", :success do
-    let(:completion) { gemini.complete("Hello!") }
+    let(:completion) { gemini.complete(LLM::Message.new("user", "Hello!")) }
 
     it "has model" do
       expect(completion.model).to eq("gemini-1.5-flash-001")
@@ -112,6 +112,6 @@ RSpec.describe "LLM::Gemini" do
   end
 
   it "returns an authentication error", :auth_error do
-    expect { gemini.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
+    expect { gemini.complete(LLM::Message.new("user", "Hello!")) }.to raise_error(LLM::Error::Unauthorized)
   end
 end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "LLM::OpenAI" do
   end
 
   context "with successful completion", :success do
-    let(:completion) { openai.complete("Hello!") }
+    let(:completion) { openai.complete(LLM::Message.new("user", "Hello!")) }
 
     it "has model" do
       expect(completion.model).to eq("gpt-4o-mini-2024-07-18")
@@ -94,11 +94,11 @@ RSpec.describe "LLM::OpenAI" do
 
   context "with an unauthorized error", :unauthorized do
     it "raises an error" do
-      expect { openai.complete("Hello!") }.to raise_error(LLM::Error::Unauthorized)
+      expect { openai.complete(LLM::Message.new("user", "Hello!")) }.to raise_error(LLM::Error::Unauthorized)
     end
 
     it "includes the response" do
-      openai.complete("Hello!")
+      openai.complete(LLM::Message.new("user", "Hello!"))
     rescue LLM::Error::Unauthorized => ex
       expect(ex.response).to be_kind_of(Net::HTTPResponse)
     end


### PR DESCRIPTION
- Changed `Provider#complete` signature to take a `Message` parameter rather than separate prompt and role.
- Inlining `PATH` for `Provider#complete`.