### PR TITLE
Implement Vision API for `Provider#complete`

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -89,9 +89,9 @@ module LLM
 
     ##
     # Transforms the prompt before sending it
-    # @param [String] prompt
+    # @param [String, URI, Object] prompt
     #  The prompt to transform
-    # @return [String]
+    # @return [Object]
     #  The transformed prompt
     def transform_prompt(prompt)
       prompt

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -41,6 +41,7 @@ module LLM
     # @raise (see LLM::Provider#complete)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
+      prompt = transform_prompt(prompt)
       completion = complete(Message.new(role, prompt), **params)
       thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
       Conversation.new(self, thread)
@@ -84,6 +85,16 @@ module LLM
       req.body = JSON.generate(body)
       auth(req)
       req
+    end
+
+    ##
+    # Transforms the prompt before sending it
+    # @param [String] prompt
+    #  The prompt to transform
+    # @return [String]
+    #  The transformed prompt
+    def transform_prompt(prompt)
+      prompt
     end
   end
 end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -43,5 +43,17 @@ module LLM
     def response_parser
       LLM::Anthropic::ResponseParser
     end
+
+    def transform_prompt(prompt)
+      return unless URI === prompt
+      [{
+        type: :image,
+        source: {
+          type: :base64,
+          media_type: prompt.content_type,
+          data: [prompt.to_s].pack('m0')
+        }
+      }]
+    end
   end
 end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -44,16 +44,22 @@ module LLM
       LLM::Anthropic::ResponseParser
     end
 
+    ##
+    # @param prompt (see LLM::Provider#transform_prompt)
+    # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      return unless URI === prompt
-      [{
-        type: :image,
-        source: {
-          type: :base64,
-          media_type: prompt.content_type,
-          data: [prompt.to_s].pack('m0')
-        }
-      }]
+      if URI === prompt
+        [{
+          type: :image,
+          source: {
+            type: :base64,
+            media_type: prompt.content_type,
+            data: [prompt.to_s].pack("m0")
+          }
+        }]
+      else
+        prompt
+      end
     end
   end
 end

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -44,9 +44,14 @@ module LLM
       LLM::OpenAI::ResponseParser
     end
 
+    ##
+    # @param prompt (see LLM::Provider#transform_prompt)
+    # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
       if URI === prompt
-        return [{type: :image_url, image_url: {url: prompt.to_s}}]
+        [{type: :image_url, image_url: {url: prompt.to_s}}]
+      else
+        prompt
       end
     end
   end

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -43,5 +43,11 @@ module LLM
     def response_parser
       LLM::OpenAI::ResponseParser
     end
+
+    def transform_prompt(prompt)
+      if URI === prompt
+        return [{type: :image_url, image_url: {url: prompt.to_s}}]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes
- Added `Provider#transform_prompt` to handle URI-based image prompts
- Implemented image support via URI for `OpenAI#chat` and `Anthropic#chat`

## Examples
```ruby
image_url = "https://upload.wikimedia.org/wikipedia/commons/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg"

LLM.openai(OPENAI_KEY).chat(URI(image_url)).thread.last

#<LLM::Message:0x00007501ab6633a8
 @content=
  "This image depicts a serene path made of wooden planks winding through lush green grass and vegetation under a blue sky with soft white clouds. The scene evokes a sense of tranquility and connection to nature, inviting one to explore the landscape ahead. It captures the beauty of an open natural space, possibly a wetland or meadow, emphasizing the lushness of the environment.",
 @role="assistant">
```