### PR TITLE
Enable vision API for lazy conversations

### DIFF
--- a/lib/llm/lazy_conversation.rb
+++ b/lib/llm/lazy_conversation.rb
@@ -29,7 +29,13 @@ module LLM
     # @param prompt (see LLM::Provider#prompt)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      tap { @thread << [prompt, role, params] }
+      tap { @thread << [transform_prompt(prompt), role, params] }
+    end
+
+    private
+
+    def transform_prompt(...)
+      @provider.transform_prompt(...)
     end
   end
 end

--- a/lib/llm/lazy_thread.rb
+++ b/lib/llm/lazy_thread.rb
@@ -33,9 +33,10 @@ module LLM
 
     def complete!
       prompt, role, params = @thread[-1]
+      mesg = LLM::Message.new(role, prompt)
       rest = @thread[0..-2].map { (Array === _1) ? LLM::Message.new(_1[1], _1[0]) : _1 }
-      comp = @provider.complete(prompt, role, **params.merge(messages: rest)).choices.last
-      [*rest, LLM::Message.new(role, prompt), comp]
+      comp = @provider.complete(mesg, **params.merge(messages: rest)).choices.last
+      [*rest, mesg, comp]
     end
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -57,6 +57,16 @@ module LLM
       LazyConversation.new(self).chat(prompt, role, **params)
     end
 
+    ##
+    # Transforms the prompt before sending it
+    # @param [String, URI, Object] prompt
+    #  The prompt to transform
+    # @return [Object]
+    #  The transformed prompt
+    def transform_prompt(prompt)
+      prompt
+    end
+
     private
 
     ##
@@ -85,16 +95,6 @@ module LLM
       req.body = JSON.generate(body)
       auth(req)
       req
-    end
-
-    ##
-    # Transforms the prompt before sending it
-    # @param [String, URI, Object] prompt
-    #  The prompt to transform
-    # @return [Object]
-    #  The transformed prompt
-    def transform_prompt(prompt)
-      prompt
     end
   end
 end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -34,16 +34,6 @@ module LLM
       Response::Completion.new(res.body, self).extend(response_parser)
     end
 
-    private
-
-    def auth(req)
-      req["x-api-key"] = @secret
-    end
-
-    def response_parser
-      LLM::Anthropic::ResponseParser
-    end
-
     ##
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
@@ -60,6 +50,16 @@ module LLM
       else
         prompt
       end
+    end
+
+    private
+
+    def auth(req)
+      req["x-api-key"] = @secret
+    end
+
+    def response_parser
+      LLM::Anthropic::ResponseParser
     end
   end
 end

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -34,16 +34,6 @@ module LLM
       Response::Completion.new(res.body, self).extend(response_parser)
     end
 
-    private
-
-    def auth(req)
-      req["Authorization"] = "Bearer #{@secret}"
-    end
-
-    def response_parser
-      LLM::OpenAI::ResponseParser
-    end
-
     ##
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
@@ -53,6 +43,16 @@ module LLM
       else
         prompt
       end
+    end
+
+    private
+
+    def auth(req)
+      req["Authorization"] = "Bearer #{@secret}"
+    end
+
+    def response_parser
+      LLM::OpenAI::ResponseParser
     end
   end
 end


### PR DESCRIPTION
This change enables lazy conversations with the vision API
for png, gif, and jpg images. Example:

```ruby
llm = LLM.openai(key)
bot = llm.chat! URI("https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg")
bot.chat "Tell me about the image"
bot.thread.each do |message|
  # A single request is fired at this point
  print "[#{message.role}] ", message.content, "\n"
end
```