### PR TITLE
Add per-provider error handlers

### DIFF
--- a/lib/llm/error.rb
+++ b/lib/llm/error.rb
@@ -10,7 +10,7 @@ module LLM
 
     ##
     # The superclass of all HTTP protocol errors
-    class HTTPError < Error
+    class BadResponse < Error
       ##
       # @return [Net::HTTPResponse]
       #  Returns the response associated with an error
@@ -19,10 +19,10 @@ module LLM
 
     ##
     # HTTPUnauthorized
-    Unauthorized = Class.new(HTTPError)
+    Unauthorized = Class.new(BadResponse)
 
     ##
     # HTTPTooManyRequests
-    RateLimit = Class.new(HTTPError)
+    RateLimit = Class.new(BadResponse)
   end
 end

--- a/lib/llm/http_client.rb
+++ b/lib/llm/http_client.rb
@@ -15,7 +15,7 @@ module LLM
     #  When authentication fails
     # @raise [LLM::Error::RateLimit]
     #  When the rate limit is exceeded
-    # @raise [LLM::Error::HTTPError]
+    # @raise [LLM::Error::BadResponse]
     #  When any other unsuccessful status code is returned
     # @raise [SystemCallError]
     #  When there is a network error at the operating system level

--- a/lib/llm/http_client.rb
+++ b/lib/llm/http_client.rb
@@ -23,17 +23,7 @@ module LLM
       res = http.request(req)
       res.tap(&:value)
     rescue Net::HTTPClientException
-      if [
-        Net::HTTPBadRequest,   # Gemini (huh?)
-        Net::HTTPForbidden,    # Anthropic
-        Net::HTTPUnauthorized  # OpenAI
-      ].any? { _1 === res }
-        raise LLM::Error::Unauthorized.new { _1.response = res }, "Authentication error"
-      elsif Net::HTTPTooManyRequests === res
-        raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
-      else
-        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
-      end
+      error_handler.new(res).raise_error!
     end
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -89,10 +89,19 @@ module LLM
 
     ##
     # @return [Module]
-    #  Returns the module responsible for parsing the LLM response
+    #  Returns the module responsible for parsing a successful LLM response
     # @raise [NotImplementedError]
     #  (see LLM::Provider#complete)
     def response_parser
+      raise NotImplementedError
+    end
+
+    ##
+    # @return [Class]
+    #  Returns the class responsible for handling an unsuccessful LLM response
+    # @raise [NotImplementedError]
+    #  (see LLM::Provider#complete)
+    def error_handler
       raise NotImplementedError
     end
 

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -5,6 +5,7 @@ module LLM
   # The Anthropic class implements a provider for
   # [Anthropic](https://www.anthropic.com)
   class Anthropic < Provider
+    require_relative "anthropic/error_handler"
     require_relative "anthropic/response_parser"
 
     HOST = "api.anthropic.com"
@@ -60,6 +61,10 @@ module LLM
 
     def response_parser
       LLM::Anthropic::ResponseParser
+    end
+
+    def error_handler
+      LLM::Anthropic::ErrorHandler
     end
   end
 end

--- a/lib/llm/providers/anthropic/error_handler.rb
+++ b/lib/llm/providers/anthropic/error_handler.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class LLM::Anthropic
+  class ErrorHandler
+    ##
+    # @return [Net::HTTPResponse]
+    #  Non-2XX response from the server
+    attr_reader :res
+
+    ##
+    # @param [Net::HTTPResponse] res
+    #  The response from the server
+    # @return [LLM::Anthropic::ErrorHandler]
+    def initialize(res)
+      @res = res
+    end
+
+    ##
+    # @raise [LLM::Error]
+    #  Raises a subclass of {LLM::Error LLM::Error}
+    def raise_error!
+      case res
+      when Net::HTTPForbidden
+        raise LLM::Error::Unauthorized.new { _1.response = res }, "Authentication error"
+      when Net::HTTPTooManyRequests
+        raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
+      else
+        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+      end
+    end
+  end
+end

--- a/lib/llm/providers/anthropic/error_handler.rb
+++ b/lib/llm/providers/anthropic/error_handler.rb
@@ -25,7 +25,7 @@ class LLM::Anthropic
       when Net::HTTPTooManyRequests
         raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
       else
-        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+        raise LLM::Error::BadResponse.new { _1.response = res }, "Unexpected response"
       end
     end
   end

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -5,6 +5,7 @@ module LLM
   # The Gemini class implements a provider for
   # [Gemini](https://ai.google.dev/)
   class Gemini < Provider
+    require_relative "gemini/error_handler"
     require_relative "gemini/response_parser"
 
     HOST = "generativelanguage.googleapis.com"
@@ -48,6 +49,10 @@ module LLM
 
     def response_parser
       LLM::Gemini::ResponseParser
+    end
+
+    def error_handler
+      LLM::Gemini::ErrorHandler
     end
   end
 end

--- a/lib/llm/providers/gemini/error_handler.rb
+++ b/lib/llm/providers/gemini/error_handler.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class LLM::Gemini
+  class ErrorHandler
+    ##
+    # @return [Net::HTTPResponse]
+    #  Non-2XX response from the server
+    attr_reader :res
+
+    ##
+    # @param [Net::HTTPResponse] res
+    #  The response from the server
+    # @return [LLM::Gemini::ErrorHandler]
+    def initialize(res)
+      @res = res
+    end
+
+    ##
+    # @raise [LLM::Error]
+    #  Raises a subclass of {LLM::Error LLM::Error}
+    def raise_error!
+      case res
+      when Net::HTTPBadRequest
+        # FIXME:
+        # Parse the response body for more information
+        # Based on the request body, raise a more specific error
+        raise LLM::Error::Unauthorized.new { _1.response = res }, "Authentication error"
+      when Net::HTTPTooManyRequests
+        raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
+      else
+        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+      end
+    end
+  end
+end

--- a/lib/llm/providers/gemini/error_handler.rb
+++ b/lib/llm/providers/gemini/error_handler.rb
@@ -28,7 +28,7 @@ class LLM::Gemini
       when Net::HTTPTooManyRequests
         raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
       else
-        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+        raise LLM::Error::BadResponse.new { _1.response = res }, "Unexpected response"
       end
     end
   end

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -5,6 +5,7 @@ module LLM
   # The OpenAI class implements a provider for
   # [OpenAI](https://platform.openai.com/)
   class OpenAI < Provider
+    require_relative "openai/error_handler"
     require_relative "openai/response_parser"
 
     HOST = "api.openai.com"
@@ -53,6 +54,10 @@ module LLM
 
     def response_parser
       LLM::OpenAI::ResponseParser
+    end
+
+    def error_handler
+      LLM::OpenAI::ErrorHandler
     end
   end
 end

--- a/lib/llm/providers/openai/error_handler.rb
+++ b/lib/llm/providers/openai/error_handler.rb
@@ -25,7 +25,7 @@ class LLM::OpenAI
       when Net::HTTPTooManyRequests
         raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
       else
-        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+        raise LLM::Error::BadResponse.new { _1.response = res }, "Unexpected response"
       end
     end
   end

--- a/lib/llm/providers/openai/error_handler.rb
+++ b/lib/llm/providers/openai/error_handler.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class LLM::OpenAI
+  class ErrorHandler
+    ##
+    # @return [Net::HTTPResponse]
+    #  Non-2XX response from the server
+    attr_reader :res
+
+    ##
+    # @param [Net::HTTPResponse] res
+    #  The response from the server
+    # @return [LLM::OpenAI::ErrorHandler]
+    def initialize(res)
+      @res = res
+    end
+
+    ##
+    # @raise [LLM::Error]
+    #  Raises a subclass of {LLM::Error LLM::Error}
+    def raise_error!
+      case res
+      when Net::HTTPUnauthorized
+        raise LLM::Error::Unauthorized.new { _1.response = res }, "Authentication error"
+      when Net::HTTPTooManyRequests
+        raise LLM::Error::RateLimit.new { _1.response = res }, "Too many requests"
+      else
+        raise LLM::Error::HTTPError.new { _1.response = res }, "Unexpected response"
+      end
+    end
+  end
+end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "LLM::OpenAI" do
     subject(:chat) { openai.chat(URI("/path/to/nowhere.bin")) }
 
     it "raises an error" do
-      expect { chat } .to raise_error(LLM::Error::HTTPError)
+      expect { chat } .to raise_error(LLM::Error::BadResponse)
     end
 
     it "is a bad request" do

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe "LLM::OpenAI" do
       .to_return(
         status: 400,
         body: {
-          "error": {
-            "message": "Failed to download image from /path/to/nowhere.bin. Image URL is invalid.",
-            "type": "invalid_request_error",
-            "param": nil,
-            "code": "invalid_image_url"
+          error: {
+            message: "Failed to download image from /path/to/nowhere.bin. Image URL is invalid.",
+            type: "invalid_request_error",
+            param: nil,
+            code: "invalid_image_url"
           }
-        }.to_json,
+        }.to_json
       )
   end
 
@@ -124,7 +124,7 @@ RSpec.describe "LLM::OpenAI" do
     subject(:chat) { openai.chat(URI("/path/to/nowhere.bin")) }
 
     it "raises an error" do
-      expect { chat } .to raise_error(LLM::Error::BadResponse)
+      expect { chat }.to raise_error(LLM::Error::BadResponse)
     end
 
     it "responds with bad request" do

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "LLM::OpenAI" do
       expect { chat } .to raise_error(LLM::Error::BadResponse)
     end
 
-    it "is a bad request" do
+    it "responds with bad request" do
       chat
     rescue LLM::Error => ex
       expect(ex.response).to be_instance_of(Net::HTTPBadRequest)


### PR DESCRIPTION
This change implements an `ErrorHandler` per-provider.
Fix #35 