### PR TITLE
Refactor `Provider#initialize` to parametrize configuration

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -15,24 +15,24 @@ module LLM
   ##
   # @param secret (see LLM::Anthropic#initialize)
   # @return (see LLM::Anthropic#initialize)
-  def anthropic(secret)
+  def anthropic(secret, **)
     require_relative "llm/providers/anthropic" unless defined?(LLM::Anthropic)
-    LLM::Anthropic.new(secret)
+    LLM::Anthropic.new(secret, **)
   end
 
   ##
   # @param secret (see LLM::Gemini#initialize)
   # @return (see LLM::Gemini#initialize)
-  def gemini(secret)
+  def gemini(secret, **)
     require_relative "llm/providers/gemini" unless defined?(LLM::Gemini)
-    LLM::Gemini.new(secret)
+    LLM::Gemini.new(secret, **)
   end
 
   ##
   # @param secret (see LLM::OpenAI#initialize)
   # @return (see LLM::OpenAI#initialize)
-  def openai(secret)
+  def openai(secret, **)
     require_relative "llm/providers/openai" unless defined?(LLM::OpenAI)
-    LLM::OpenAI.new(secret)
+    LLM::OpenAI.new(secret, **)
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -14,10 +14,10 @@ module LLM
     #  The host address of the LLM provider
     # @param [Integer] port
     #  The port number
-    def initialize(secret, host, port = 443)
+    def initialize(secret, host:, port: 443, ssl: true)
       @secret = secret
       @http = Net::HTTP.new(host, port).tap do |http|
-        http.use_ssl = true
+        http.use_ssl = ssl
       end
     end
 

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -13,8 +13,8 @@ module LLM
 
     ##
     # @param secret (see LLM::Provider#initialize)
-    def initialize(secret)
-      super(secret, HOST)
+    def initialize(secret, **)
+      super(secret, host: HOST, **)
     end
 
     def embed(input, **params)

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -13,8 +13,8 @@ module LLM
 
     ##
     # @param secret (see LLM::Provider#initialize)
-    def initialize(secret)
-      super(secret, HOST)
+    def initialize(secret, **)
+      super(secret, host: HOST, **)
     end
 
     def embed(input, **params)

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -13,8 +13,8 @@ module LLM
 
     ##
     # @param secret (see LLM::Provider#initialize)
-    def initialize(secret)
-      super(secret, HOST)
+    def initialize(secret, **)
+      super(secret, host: HOST, **)
     end
 
     def embed(input, **params)


### PR DESCRIPTION
## Changes
- Allow `host`, `port` and `ssl` to be passed to provider initializer