### PR TITLE
fix: use role value from response in Anthropic parser

### DIFF
--- a/lib/llm/providers/anthropic/response_parser.rb
+++ b/lib/llm/providers/anthropic/response_parser.rb
@@ -20,8 +20,7 @@ class LLM::Anthropic
       {
         model: raw["model"],
         choices: raw["content"].map do
-          # TODO: don't hardcode role
-          LLM::Message.new("assistant", _1["text"])
+          LLM::Message.new(raw["role"], _1["text"])
         end,
         prompt_tokens: raw.dig("usage", "input_tokens"),
         completion_tokens: raw.dig("usage", "output_tokens")


### PR DESCRIPTION
## Changes
- Use role value from the parser in Anthropic instead of the hardcoded "assistant"