### PR TITLE
feat: add log probabilities to OpenAI

### DIFF
--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -2,11 +2,12 @@
 
 module LLM
   class Message
-    attr_accessor :role, :content
+    attr_accessor :role, :content, :logprobs, :top_logprobs
 
-    def initialize(role, content)
+    def initialize(role, content, logprobs: nil)
       @role = role
       @content = content
+      @logprobs = logprobs
     end
 
     def to_h

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -2,12 +2,16 @@
 
 module LLM
   class Message
-    attr_accessor :role, :content, :logprobs, :top_logprobs
+    attr_accessor :role, :content
 
-    def initialize(role, content, logprobs: nil)
+    def initialize(role, content, extra = nil)
       @role = role
       @content = content
-      @logprobs = logprobs
+      @extra = extra
+    end
+
+    def logprobs
+      extra[:logprobs]
     end
 
     def to_h

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -10,6 +10,10 @@ module LLM
       @extra = extra
     end
 
+    ##
+    # @see https://platform.openai.com/docs/api-reference/chat/object logprobs docs
+    # Returns log probabilities
+    # @return [Hash]
     def logprobs
       @extra[:logprobs]
     end

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -11,7 +11,7 @@ module LLM
     end
 
     ##
-    # @see https://platform.openai.com/docs/api-reference/chat/object logprobs docs
+    # @see https://platform.openai.com/docs/api-reference/chat/object#chat/object-choices logprobs docs
     # Returns log probabilities
     # @return [Hash]
     def logprobs

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -4,7 +4,7 @@ module LLM
   class Message
     attr_accessor :role, :content
 
-    def initialize(role, content, extra = nil)
+    def initialize(role, content, extra = {})
       @role = role
       @content = content
       @extra = extra

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -12,6 +12,8 @@ module LLM
 
     ##
     # @see https://platform.openai.com/docs/api-reference/chat/object#chat/object-choices logprobs docs
+    # @see https://cookbook.openai.com/examples/using_logprobs logprobs cookbook
+    # @note logprobs are specific to OpenAI for now
     # Returns log probabilities
     # @return [Hash]
     def logprobs

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -11,7 +11,7 @@ module LLM
     end
 
     def logprobs
-      extra[:logprobs]
+      @extra[:logprobs]
     end
 
     def to_h

--- a/lib/llm/providers/openai/response_parser.rb
+++ b/lib/llm/providers/openai/response_parser.rb
@@ -19,7 +19,7 @@ class LLM::OpenAI
       {
         model: raw["model"],
         choices: raw["choices"].map do
-          LLM::Message.new(*_1["message"].values_at("role", "content"))
+          LLM::Message.new(*_1["message"].values_at("role", "content"), logprobs: _1["logprobs"])
         end,
         prompt_tokens: raw.dig("usage", "prompt_tokens"),
         completion_tokens: raw.dig("usage", "completion_tokens"),

--- a/lib/llm/providers/openai/response_parser.rb
+++ b/lib/llm/providers/openai/response_parser.rb
@@ -19,7 +19,7 @@ class LLM::OpenAI
       {
         model: raw["model"],
         choices: raw["choices"].map do
-          LLM::Message.new(*_1["message"].values_at("role", "content"), logprobs: _1["logprobs"])
+          LLM::Message.new(*_1["message"].values_at("role", "content"), {logprobs: _1["logprobs"]})
         end,
         prompt_tokens: raw.dig("usage", "prompt_tokens"),
         completion_tokens: raw.dig("usage", "completion_tokens"),


### PR DESCRIPTION
## Changes
- Implement log probabilities for the OpenAI provider

## Examples
The following example is a reproduction of the work in [https://cookbook.openai.com/examples/using_logprobs](url)

```ruby
require "llm"

def prompt(headline)
  "You will be given a headline of a news article.
  Classify the article into one of the following categories: Technology, Politics, Sports, and Art.
  Return only the name of the category, and nothing else.
  MAKE SURE your output is one of the four categories stated.
  Article headline: #{headline}"
end

headlines = [
    "Tech Giant Unveils Latest Smartphone Model with Advanced Photo-Editing Features.",
    "Local Mayor Launches Initiative to Enhance Urban Public Transport.",
    "Tennis Champion Showcases Hidden Talents in Symphony Orchestra Debut",
]

# Categorizing headlines without any confidence levels 
headlines.each do |headline|
  completion = LLM.openai(OPENAI_KEY).complete(LLM::Message.new("user", prompt(headline)))
  puts "#{headline} - #{completion.choices.first.content}"
end

# Categorizing headlines with confidence levels through log probabilities (Note the last headline)
headlines.each do |headline|
  completion = LLM.openai(OPENAI_KEY).complete(LLM::Message.new("user", prompt(headline)), logprobs: true, top_logprobs: 2)
  logprobs = completion.choices.first.logprobs["content"]
  logprobs.first["top_logprobs"].each_with_index do |p, i|
    probability = Math.exp(p['logprob']).round(2) * 100
    puts "Token #{i}: #{p['token']}"
    puts "  Logprobs: #{p['logprob']}"
    puts "  Linear probability: #{probability}%"
    puts "\n"
  end
end

```