### PR TITLE
Match Conversation <=> LazyConversation interfaces 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,75 @@
-# LLM
+## About
 
 A lightweight Ruby library for interacting with multiple LLM providers
 
-## Install
-
 ## Examples
 
-### Conversation
+### LazyConversation
 
 The
 [`LLM::Provider#chat`](https://0x1eef.github.io/x/llm/LLM/Provider.html#chat-instance_method)
 method returns a
-[`LLM::Conversation`](https://0x1eef.github.io/x/llm/LLM/Conversation.html)
-object that
-can maintain a conversation with a LLM provider. Because a conversation has a
-thread of messages the LLM has a certain amount of extra context that can re-used within the conversation.
-With the following example each call to `chat` corresponds to a HTTP request
-to the provider:
+[`LLM::LazyConversation`](https://0x1eef.github.io/x/llm/LLM/LazyConversation.html)
+object
+that can maintain a "lazy" conversation where input prompts are sent to the
+provider only when needed. Once a conversation is initiated it will maintain a
+thread of messages that provide the LLM with a certain amount of extra context
+that can be re-used within the conversation:
 
 ```ruby
 #!/usr/bin/env ruby
 require "llm"
 
 llm = LLM.openai("yourapikey")
-bot = llm.chat "be a helpful assistant", :system
+bot = llm.chat "keep the answer concise", :system
+bot.chat URI("https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg")
+bot.chat "What is the frog's name?"
+bot.chat "What is the frog's habitat?"
+bot.chat "What is the frog's diet?"
+
+##
+# At this point a single request is made to the provider
+# See 'LLM::LazyThread#each' for more details
+bot.thread.each do |message|
+  print "[#{message.role}] ", message.content, "\n"
+end
+
+##
+# [system] keep the answer concise
+# [user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]
+# [user] What is the frog's name?
+# [user] What is the frog's habitat?
+# [user] What is the frog's diet?
+# [assistant] The frog in the image is likely a Red-eyed Tree Frog.
+#
+#  #### Habitat:
+#  - Typically found in tropical rainforests, especially in Central America.
+#
+#  #### Diet:
+#   - Primarily insectivorous, feeding on insects like crickets and moths.
+```
+
+### Conversation
+
+The
+[`LLM::Provider#chat`](https://0x1eef.github.io/x/llm/LLM/Provider.html#chat!-instance_method)
+method returns a
+[`LLM::Conversation`](https://0x1eef.github.io/x/llm/LLM/Conversation.html)
+object that can maintain a conversation with a LLM provider but unlike
+[`LLM::LazyConversation`](https://0x1eef.github.io/x/llm/LLM/LazyConversation.html)
+each call to `chat!` / `chat` corresponds to a HTTP request to the provider:
+
+```ruby
+#!/usr/bin/env ruby
+require "llm"
+
+llm = LLM.openai("yourapikey")
+bot = llm.chat! "be a helpful assistant", :system
 bot.chat "keep the answers short and sweet", :system
 bot.chat "help me choose a good book"
 bot.chat "books of poetry"
 bot.thread.each do |message|
-  print "[#{message.role}] ", message.text, "\n"
+  print "[#{message.role}] ", message.content, "\n"
 end
 
 ##
@@ -50,52 +91,26 @@ end
 # Happy reading!
 ```
 
-### Lazy conversation
+## Providers
 
-The
-[`LLM::Provider#chat!`](https://0x1eef.github.io/x/llm/LLM/Provider.html#chat!-instance_method)
-method returns a
-[`LLM::LazyConversation`](https://0x1eef.github.io/x/llm/LLM/LazyConversation.html)
-object
-that can maintain a "lazy" conversation where input prompts are sent to the
-provider only when needed. The following example demonstrates a lazy conversation
-with the OpenAI provider:
-
-```ruby
-#!/usr/bin/env ruby
-require "llm"
-
-llm = LLM.openai("yourapikey")
-bot = llm.chat! URI("https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg")
-bot.chat "What is the frog's name?"
-bot.chat "What is the frog's habitat?"
-bot.chat "What is the frog's diet?"
-bot.thread.each do |message|
-  print "[#{message.role}] ", message.content, "\n"
-end
-
-##
-# [user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]
-# [system] keep the answer concise
-# [user] What is the frog's name?
-# [user] What is the frog's habitat?
-# [user] What is the frog's diet?
-# [assistant] The frog in the image is likely a Red-eyed Tree Frog.
-#
-#  #### Habitat:
-#  - Typically found in tropical rainforests, especially in Central America.
-#
-#  #### Diet:
-#   - Primarily insectivorous, feeding on insects like crickets and moths.
-```
-
-## Available providers
-
-- [x] Anthropic
-- [x] OpenAI
-- [x] Gemini
+- [x] [Anthropic](https://www.anthropic.com/)
+- [x] [OpenAI](https://platform.openai.com/docs/overview)
+- [x] [Gemini](https://ai.google.dev/gemini-api/docs)
+- [x] [Ollama](https://github.com/ollama/ollama#readme)
 - [ ] Hugging Face
 - [ ] Cohere
 - [ ] AI21 Labs
 - [ ] Replicate
 - [ ] Mistral AI
+
+## Documentation
+
+A complete API reference is available at [0x1eef.github.io/x/llm](https://0x1eef.github.io/x/llm)
+
+## Install
+
+LLM has not been published to RubyGems.org yet. Stay tuned
+
+## License
+
+MIT. See [LICENSE.txt](LICENSE.txt) for more details

--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -30,7 +30,7 @@ module LLM
       tap do
         prompt = transform_prompt(prompt)
         completion = @provider.complete(Message.new(role, prompt), **params)
-        @thread.concat [ Message.new(role.to_s, prompt), completion.choices.first ]
+        @thread.concat [Message.new(role.to_s, prompt), completion.choices.first]
       end
     end
 

--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -16,13 +16,11 @@ module LLM
     attr_reader :thread
 
     ##
-    # @param [Array<LLM::Message>] thread
-    #  An array of messages that form the conversation history
     # @param [LLM::Provider] provider
     #  A provider
-    def initialize(provider, thread)
+    def initialize(provider)
       @provider = provider
-      @thread = thread
+      @thread = []
     end
 
     ##
@@ -30,11 +28,16 @@ module LLM
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
       tap do
-        bot = @provider.chat(prompt, role, **params.merge(messages: @thread))
-        # The last two elements of the thread include the
-        # last input prompt, and the response from the LLM
-        @thread.concat(bot.thread[-2..])
+        prompt = transform_prompt(prompt)
+        completion = @provider.complete(Message.new(role, prompt), **params)
+        @thread.concat [ Message.new(role.to_s, prompt), completion.choices.first ]
       end
+    end
+
+    private
+
+    def transform_prompt(...)
+      @provider.transform_prompt(...)
     end
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -59,10 +59,7 @@ module LLM
     # @raise (see LLM::Provider#complete)
     # @return [LLM::Conversation]
     def chat!(prompt, role = :user, **params)
-      prompt = transform_prompt(prompt)
-      completion = complete(Message.new(role, prompt), **params)
-      thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
-      Conversation.new(self, thread).chat(prompt, role, **params)
+      Conversation.new(self).chat(prompt, role, **params)
     end
 
     ##

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -43,26 +43,26 @@ module LLM
     end
 
     ##
+    # Starts a new lazy conversation
+    # @param prompt (see LLM::Provider#complete)
+    # @param role (see LLM::Provider#complete)
+    # @raise (see LLM::Provider#complete)
+    # @return [LLM::LazyConversation]
+    def chat(prompt, role = :user, **params)
+      LazyConversation.new(self).chat(prompt, role, **params)
+    end
+
+    ##
     # Starts a new conversation
     # @param prompt (see LLM::Provider#complete)
     # @param role (see LLM::Provider#complete)
     # @raise (see LLM::Provider#complete)
     # @return [LLM::Conversation]
-    def chat(prompt, role = :user, **params)
+    def chat!(prompt, role = :user, **params)
       prompt = transform_prompt(prompt)
       completion = complete(Message.new(role, prompt), **params)
       thread = [*params[:messages], Message.new(role.to_s, prompt), completion.choices.first]
-      Conversation.new(self, thread)
-    end
-
-    ##
-    # Starts a lazy conversation
-    # @param prompt (see LLM::Provider#complete)
-    # @param role (see LLM::Provider#complete)
-    # @raise (see LLM::Provider#complete)
-    # @return [LLM::LazyResponse]
-    def chat!(prompt, role = :user, **params)
-      LazyConversation.new(self).chat(prompt, role, **params)
+      Conversation.new(self, thread).chat(prompt, role, **params)
     end
 
     ##

--- a/share/llm/examples/conversation.rb
+++ b/share/llm/examples/conversation.rb
@@ -2,7 +2,7 @@
 require "llm"
 
 llm = LLM.openai(ENV["key"])
-bot = llm.chat "be a helpful assistant", :system
+bot = llm.chat! "be a helpful assistant", :system
 bot.chat "keep the answers short and sweet", :system
 bot.chat "help me choose a good book"
 bot.chat "books of poetry"

--- a/share/llm/examples/lazy_conversation.rb
+++ b/share/llm/examples/lazy_conversation.rb
@@ -2,11 +2,15 @@
 require "llm"
 
 llm = LLM.openai(ENV["key"])
-bot = llm.chat! URI("https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg")
-bot.chat "keep the answer concise", :system
+bot = llm.chat "keep the answer concise", :system
+bot.chat URI("https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg")
 bot.chat "What is the frog's name?"
 bot.chat "What is the frog's habitat?"
 bot.chat "What is the frog's diet?"
+
+##
+# At this point a single request is made to the provider
+# See 'LLM::LazyThread#each' for more details
 bot.thread.each do |message|
   print "[#{message.role}] ", message.content, "\n"
 end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe "The README examples" do
 
     let(:expected_conversation) do
       [
-        '[user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]',
         "[system] keep the answer concise",
+        '[user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]',
         "[user] What is the frog's name?",
         "[user] What is the frog's habitat?",
         "[user] What is the frog's diet?",


### PR DESCRIPTION
#46 should be reviewed / merged first as this PR is based on it 

This change sees `LLM::Conversation` have the same interface as
`LLM::LazyConversation`. That means we have removed the second
`thread` parameter from `LLM::Conversation#initialize`.