### PR TITLE
Add `LLM::Provider#embed`

### DIFF
--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -30,6 +30,16 @@ module LLM
     end
 
     ##
+    # @param [String] input
+    #  The input to embed
+    # @raise [NotImplementedError]
+    #  When the method is not implemented by a subclass
+    # @return [LLM::Response::Embedding]
+    def embed(input, **params)
+      raise NotImplementedError
+    end
+
+    ##
     # Completes a given prompt using the LLM
     # @param [String] prompt
     #  The input prompt to be completed

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -17,6 +17,9 @@ module LLM
       super(secret, host: HOST, **)
     end
 
+    ##
+    # @param input (see LLM::Provider#embed)
+    # @return (see LLM::Provider#embed)
     def embed(input, **params)
       req = Net::HTTP::Post.new ["api.voyageai.com/v1", "embeddings"].join("/")
       body = {input:, model: "voyage-2"}.merge!(params)

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -17,6 +17,9 @@ module LLM
       super(secret, host: HOST, **)
     end
 
+    ##
+    # @param input (see LLM::Provider#embed)
+    # @return (see LLM::Provider#embed)
     def embed(input, **params)
       path = ["/v1beta/models", "text-embedding-004"].join("/")
       req = Net::HTTP::Post.new [path, "embedContent"].join(":")

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -17,6 +17,9 @@ module LLM
       super(secret, host: HOST, **)
     end
 
+    ##
+    # @param input (see LLM::Provider#embed)
+    # @return (see LLM::Provider#embed)
     def embed(input, **params)
       req = Net::HTTP::Post.new ["/v1", "embeddings"].join("/")
       body = {input:, model: "text-embedding-3-small"}.merge!(params)


### PR DESCRIPTION
When a provider doesn't implement `embed` we should raise
`NotImplemetedError` rather than `NoMethodError` as is the
case with the ollama provider and maybe other providers in
the future