### PR TITLE
Add LLM::File

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ end
 
 ##
 # [system] keep the answer concise
-# [user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]
+# [user] https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg
 # [user] What is the frog's name?
 # [user] What is the frog's habitat?
 # [user] What is the frog's diet?

--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -5,6 +5,7 @@ module LLM
   require_relative "llm/error"
   require_relative "llm/message"
   require_relative "llm/response"
+  require_relative "llm/file"
   require_relative "llm/provider"
   require_relative "llm/conversation"
   require_relative "llm/lazy_conversation"

--- a/lib/llm/file.rb
+++ b/lib/llm/file.rb
@@ -10,38 +10,38 @@ class LLM::File
     @mime_types ||= {
       ##
       # Images
-      ".png"  => "image/png",
-      ".jpg"  => "image/jpeg",
+      ".png" => "image/png",
+      ".jpg" => "image/jpeg",
       ".jpeg" => "image/jpeg",
       ".webp" => "image/webp",
 
       ##
       # Videos
-      ".flv"   => "video/x-flv",
-      ".mov"   => "video/quicktime",
-      ".mpeg"  => "video/mpeg",
-      ".mpg"   => "video/mpeg",
-      ".mp4"   => "video/mp4",
-      ".webm"  => "video/webm",
-      ".wmv"   => "video/x-ms-wmv",
-      ".3gp"   => "video/3gpp",
+      ".flv" => "video/x-flv",
+      ".mov" => "video/quicktime",
+      ".mpeg" => "video/mpeg",
+      ".mpg" => "video/mpeg",
+      ".mp4" => "video/mp4",
+      ".webm" => "video/webm",
+      ".wmv" => "video/x-ms-wmv",
+      ".3gp" => "video/3gpp",
 
       ##
       # Audio
-      ".aac"   => "audio/aac",
-      ".flac"  => "audio/flac",
-      ".mp3"   => "audio/mpeg",
-      ".m4a"   => "audio/mp4",
-      ".mpga"  => "audio/mpeg",
-      ".opus"  => "audio/opus",
-      ".pcm"   => "audio/L16",
-      ".wav"   => "audio/wav",
-      ".weba"  => "audio/webm",
+      ".aac" => "audio/aac",
+      ".flac" => "audio/flac",
+      ".mp3" => "audio/mpeg",
+      ".m4a" => "audio/mp4",
+      ".mpga" => "audio/mpeg",
+      ".opus" => "audio/opus",
+      ".pcm" => "audio/L16",
+      ".wav" => "audio/wav",
+      ".weba" => "audio/webm",
 
       ##
       # Documents
-      ".pdf"   => "application/pdf",
-      ".txt"   => "text/plain"
+      ".pdf" => "application/pdf",
+      ".txt" => "text/plain"
     }.freeze
   end
 
@@ -81,6 +81,6 @@ end
 # @param [String] path
 #  The path to a file
 # @return [LLM::File]
-def LLM::File(path)
+def LLM.File(path)
   LLM::File.new(path)
 end

--- a/lib/llm/file.rb
+++ b/lib/llm/file.rb
@@ -1,0 +1,86 @@
+##
+# {LLM::File LLM::File} is a class that represents a local file
+# that can be used as a prompt in a chat completion request
+class LLM::File
+  ##
+  # @return [Hash]
+  #  Returns a hash of common file extensions and their
+  #  corresponding MIME types
+  def self.mime_types
+    @mime_types ||= {
+      ##
+      # Images
+      ".png"  => "image/png",
+      ".jpg"  => "image/jpeg",
+      ".jpeg" => "image/jpeg",
+      ".webp" => "image/webp",
+
+      ##
+      # Videos
+      ".flv"   => "video/x-flv",
+      ".mov"   => "video/quicktime",
+      ".mpeg"  => "video/mpeg",
+      ".mpg"   => "video/mpeg",
+      ".mp4"   => "video/mp4",
+      ".webm"  => "video/webm",
+      ".wmv"   => "video/x-ms-wmv",
+      ".3gp"   => "video/3gpp",
+
+      ##
+      # Audio
+      ".aac"   => "audio/aac",
+      ".flac"  => "audio/flac",
+      ".mp3"   => "audio/mpeg",
+      ".m4a"   => "audio/mp4",
+      ".mpga"  => "audio/mpeg",
+      ".opus"  => "audio/opus",
+      ".pcm"   => "audio/L16",
+      ".wav"   => "audio/wav",
+      ".weba"  => "audio/webm",
+
+      ##
+      # Documents
+      ".pdf"   => "application/pdf",
+      ".txt"   => "text/plain"
+    }.freeze
+  end
+
+  ##
+  # @return [String]
+  #  Returns the path to a file
+  attr_reader :path
+
+  ##
+  # @param [String] path
+  #  The path to a file
+  # @return [LLM::File]
+  def initialize(path)
+    @path = path
+  end
+
+  ##
+  # @return [String]
+  #  Returns the MIME type of a file
+  def mime_type
+    self.class.mime_types[File.extname(path)]
+  end
+
+  ##
+  # @return [String]
+  #  Returns the contents of a file encoded in Base64
+  def to_base64
+    [File.binread(path)].pack("m0")
+  end
+end
+
+##
+# @example
+# llm = LLM.gemini(key)
+# bot = llm.chat LLM::File("/path/to/image.png")
+# bot.chat "Describe the image"
+# @param [String] path
+#  The path to a file
+# @return [LLM::File]
+def LLM::File(path)
+  LLM::File.new(path)
+end

--- a/lib/llm/lazy_conversation.rb
+++ b/lib/llm/lazy_conversation.rb
@@ -31,13 +31,7 @@ module LLM
     # @param prompt (see LLM::Provider#prompt)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      tap { @messages << [transform_prompt(prompt), role, params] }
-    end
-
-    private
-
-    def transform_prompt(...)
-      @provider.transform_prompt(...)
+      tap { @messages << [prompt, role, params] }
     end
   end
 end

--- a/lib/llm/message_queue.rb
+++ b/lib/llm/message_queue.rb
@@ -38,8 +38,8 @@ module LLM
     def complete!
       prompt, role, params = @messages[-1]
       rest = @messages[0..-2].map { (Array === _1) ? LLM::Message.new(_1[1], _1[0]) : _1 }
-      comp = @provider.complete(prompt, role, **params.merge(messages: rest)).choices.last
-      [*rest, LLM::Message.new(role, prompt), comp]
+      comp = @provider.complete(prompt, role, **params.merge(messages: rest))
+      [*rest, LLM::Message.new(role, prompt), comp.choices[0]]
     end
   end
 end

--- a/lib/llm/message_queue.rb
+++ b/lib/llm/message_queue.rb
@@ -37,10 +37,9 @@ module LLM
 
     def complete!
       prompt, role, params = @messages[-1]
-      mesg = LLM::Message.new(role, prompt)
       rest = @messages[0..-2].map { (Array === _1) ? LLM::Message.new(_1[1], _1[0]) : _1 }
-      comp = @provider.complete(mesg, **params.merge(messages: rest))
-      [*rest, mesg, comp.choices[0]]
+      comp = @provider.complete(prompt, role, **params.merge(messages: rest)).choices.last
+      [*rest, LLM::Message.new(role, prompt), comp]
     end
   end
 end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -73,7 +73,7 @@ module LLM
     end
 
     ##
-    # Transforms the prompt before sending it
+    # Transforms a completion prompt before sending it to the LLM
     # @param [String, URI, Object] prompt
     #  The prompt to transform
     # @return [Object]

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -42,9 +42,7 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if LLM::File === prompt
-        raise TypeError, "#{self.class} does not support LLM::File objects"
-      elsif URI === prompt
+      if URI === prompt
         [{
           type: :image,
           source: {
@@ -53,8 +51,10 @@ module LLM
             data: [prompt.to_s].pack("m0")
           }
         }]
-      else
+      elsif String === prompt
         prompt
+      else
+        raise TypeError, "#{self.class} does not support #{prompt.class} objects"
       end
     end
 

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -28,6 +28,11 @@ module LLM
       Response::Embedding.new(res.body, self)
     end
 
+    ##
+    # @see https://docs.anthropic.com/en/api/messages Anthropic docs
+    # @param prompt (see LLM::Provider#complete)
+    # @param role (see LLM::Provider#complete)
+    # @return (see LLM::Provider#complete)
     def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new ["/v1", "messages"].join("/")
       messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -42,7 +42,9 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if URI === prompt
+      if LLM::File === prompt
+        raise TypeError, "#{self.class} does not support LLM::File objects"
+      elsif URI === prompt
         [{
           type: :image,
           source: {

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -53,8 +53,10 @@ module LLM
         file = prompt
         inline_data = {mime_type: file.mime_type, data: file.to_base64}
         {inline_data:}
-      else
+      elsif String === prompt
         {text: prompt}
+      else
+        raise TypeError, "#{self.class} does not support #{prompt.class} objects"
       end
     end
 

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -39,7 +39,7 @@ module LLM
       path = ["/v1beta/models", params.delete(:model)].join("/")
       req = Net::HTTP::Post.new [path, "generateContent"].join(":")
       messages = [*(params.delete(:messages) || []), LLM::Message.new(role, transform_prompt(prompt))]
-      body = { contents: [{ parts: messages.map { _1.to_h[:content] } }] }
+      body = {contents: [{parts: messages.map { _1.to_h[:content] }}]}
       req = preflight(req, body)
       res = request(@http, req)
       Response::Completion.new(res.body, self).extend(response_parser)

--- a/lib/llm/providers/gemini/response_parser.rb
+++ b/lib/llm/providers/gemini/response_parser.rb
@@ -18,7 +18,7 @@ class LLM::Gemini
         choices: raw["candidates"].map do
           LLM::Message.new(
             _1.dig("content", "role"),
-            _1.dig("content", "parts", 0, "text")
+            {text: _1.dig("content", "parts", 0, "text")}
           )
         end,
         prompt_tokens: raw.dig("usageMetadata", "promptTokenCount"),

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -31,12 +31,12 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if LLM::File === prompt
-        raise TypeError, "#{self.class} does not support LLM::File objects"
-      elsif URI === prompt
+      if URI === prompt
         [{type: :image_url, image_url: {url: prompt.to_s}}]
-      else
+      elsif String === prompt
         prompt
+      else
+        raise TypeError, "#{self.class} does not support #{prompt.class} objects"
       end
     end
 

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -31,7 +31,9 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if URI === prompt
+      if LLM::File === prompt
+        raise TypeError, "#{self.class} does not support LLM::File objects"
+      elsif URI === prompt
         [{type: :image_url, image_url: {url: prompt.to_s}}]
       else
         prompt

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -24,7 +24,7 @@ module LLM
     # @return (see LLM::Provider#complete)
     def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new ["/api", "chat"].join("/")
-      messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]
+      messages = [*(params.delete(:messages) || []), Message.new(role.to_s, transform_prompt(prompt))]
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)
       req = preflight(req, body)

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -17,6 +17,11 @@ module LLM
       super(secret, host: HOST, port: 11434, ssl: false, **)
     end
 
+    ##
+    # @see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion Ollama docs
+    # @param prompt (see LLM::Provider#complete)
+    # @param role (see LLM::Provider#complete)
+    # @return (see LLM::Provider#complete)
     def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new ["/api", "chat"].join("/")
       messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -42,12 +42,12 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if LLM::File === prompt
-        raise TypeError, "#{self.class} does not support LLM::File objects"
-      elsif URI === prompt
+      if URI === prompt
         [{type: :image_url, image_url: {url: prompt.to_s}}]
-      else
+      elsif String === prompt
         prompt
+      else
+        raise TypeError, "#{self.class} does not support #{prompt.class} objects"
       end
     end
 

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -42,7 +42,9 @@ module LLM
     # @param prompt (see LLM::Provider#transform_prompt)
     # @return (see LLM::Provider#transform_prompt)
     def transform_prompt(prompt)
-      if URI === prompt
+      if LLM::File === prompt
+        raise TypeError, "#{self.class} does not support LLM::File objects"
+      elsif URI === prompt
         [{type: :image_url, image_url: {url: prompt.to_s}}]
       else
         prompt

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -28,6 +28,11 @@ module LLM
       Response::Embedding.new(res.body, self)
     end
 
+    ##
+    # @see https://platform.openai.com/docs/api-reference/chat/create OpenAI docs
+    # @param prompt (see LLM::Provider#complete)
+    # @param role (see LLM::Provider#complete)
+    # @return (see LLM::Provider#complete)
     def complete(prompt, role = :user, **params)
       req = Net::HTTP::Post.new ["/v1", "chat", "completions"].join("/")
       messages = [*(params.delete(:messages) || []), Message.new(role.to_s, prompt)]

--- a/spec/gemini/completion_spec.rb
+++ b/spec/gemini/completion_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe "LLM::Gemini" do
         choices: [
           have_attributes(
             role: "model",
-            content: "Hello! How can I help you today? \n"
+            content: {
+              text: "Hello! How can I help you today? \n"
+            }
           )
         ]
       )

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "The README examples" do
     let(:expected_conversation) do
       [
         "[system] keep the answer concise",
-        '[user] https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg',
+        "[user] https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg",
         "[user] What is the frog's name?",
         "[user] What is the frog's habitat?",
         "[user] What is the frog's diet?",

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "The README examples" do
     let(:expected_conversation) do
       [
         "[system] keep the answer concise",
-        '[user] [{:type=>:image_url, :image_url=>{:url=>"https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg"}}]',
+        '[user] https://upload.wikimedia.org/wikipedia/commons/b/be/Red_eyed_tree_frog_edit2.jpg',
         "[user] What is the frog's name?",
         "[user] What is the frog's habitat?",
         "[user] What is the frog's diet?",


### PR DESCRIPTION
Gemini support only (at least for now)

Example:
```ruby
require "llm"
llm = LLM.gemini(key)
bot = llm.chat LLM::File("/path/to/image.png")
bot.chat "Describe the image"
bot.messages.each do |message|
  print message.role, ": ", message.content.to_s, "\n"
end
```