### PR TITLE
Implement stop_reason

### DIFF
--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -20,6 +20,13 @@ module LLM
       @extra[:logprobs]
     end
 
+    ##
+    # Returns the stop reason
+    # @return [String]
+    def stop_reason
+      @extra[:stop_reason]
+    end
+
     def to_h
       {role:, content:}
     end

--- a/lib/llm/providers/anthropic/response_parser.rb
+++ b/lib/llm/providers/anthropic/response_parser.rb
@@ -20,7 +20,8 @@ class LLM::Anthropic
       {
         model: raw["model"],
         choices: raw["content"].map do
-          LLM::Message.new(raw["role"], _1["text"])
+          stop_reason = raw["stop_reason"]
+          LLM::Message.new(raw["role"], _1["text"], {stop_reason:})
         end,
         prompt_tokens: raw.dig("usage", "input_tokens"),
         completion_tokens: raw.dig("usage", "output_tokens")

--- a/lib/llm/providers/gemini/response_parser.rb
+++ b/lib/llm/providers/gemini/response_parser.rb
@@ -16,9 +16,11 @@ class LLM::Gemini
       {
         model: raw["modelVersion"],
         choices: raw["candidates"].map do
+          stop_reason = _1["finishReason"]
           LLM::Message.new(
             _1.dig("content", "role"),
-            {text: _1.dig("content", "parts", 0, "text")}
+            {text: _1.dig("content", "parts", 0, "text")},
+            {stop_reason:}
           )
         end,
         prompt_tokens: raw.dig("usageMetadata", "promptTokenCount"),

--- a/lib/llm/providers/ollama/response_parser.rb
+++ b/lib/llm/providers/ollama/response_parser.rb
@@ -7,7 +7,7 @@ class LLM::Ollama
     def parse_completion(raw)
       {
         model: raw["model"],
-        choices: [LLM::Message.new(*raw["message"].values_at("role", "content"))],
+        choices: [LLM::Message.new(*raw["message"].values_at("role", "content"), {stop_reason: raw["done_reason"]})],
         prompt_tokens: raw.dig("prompt_eval_count"),
         completion_tokens: raw.dig("eval_count")
       }

--- a/lib/llm/providers/openai/response_parser.rb
+++ b/lib/llm/providers/openai/response_parser.rb
@@ -19,7 +19,9 @@ class LLM::OpenAI
       {
         model: raw["model"],
         choices: raw["choices"].map do
-          LLM::Message.new(*_1["message"].values_at("role", "content"), {logprobs: _1["logprobs"]})
+          logprobs = _1["logprobs"]
+          stop_reason = _1["finish_reason"]
+          LLM::Message.new(*_1["message"].values_at("role", "content"), {logprobs:, stop_reason:})
         end,
         prompt_tokens: raw.dig("usage", "prompt_tokens"),
         completion_tokens: raw.dig("usage", "completion_tokens"),

--- a/spec/anthropic/completion_spec.rb
+++ b/spec/anthropic/completion_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe "LLM::Anthropic" do
         total_tokens: 2598
       )
     end
+
+    it "has stop reason" do
+      expect(completion.choices.first.stop_reason).to eq("end_turn")
+    end
   end
 
   context "with an unauthorized error", :unauthorized do

--- a/spec/gemini/completion_spec.rb
+++ b/spec/gemini/completion_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe "LLM::Gemini" do
         total_tokens: 12
       )
     end
+
+    it "has stop_reason" do
+      expect(completion.choices.first.stop_reason).to eq("STOP")
+    end
   end
 
   context "with an unauthorized error", :unauthorized do

--- a/spec/ollama/completion_spec.rb
+++ b/spec/ollama/completion_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "LLM::Ollama" do
             "content": "Hello! How are you today?"
           },
           "done": true,
+          "done_reason": "stop",
           "total_duration": 5191566416,
           "load_duration": 2154458,
           "prompt_eval_count": 26,
@@ -86,6 +87,10 @@ RSpec.describe "LLM::Ollama" do
         completion_tokens: 298,
         total_tokens: 324
       )
+    end
+
+    it "has stop reason for first choice" do
+      expect(completion.choices.first.stop_reason).to eq("stop")
     end
   end
 

--- a/spec/openai/completion_spec.rb
+++ b/spec/openai/completion_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe "LLM::OpenAI" do
         total_tokens: 18
       )
     end
+
+    it "has stop reason" do
+      expect(completion.choices.first.stop_reason).to eq("stop")
+    end
   end
 
   context "with an unauthorized error", :unauthorized do


### PR DESCRIPTION
## Changes
- Add `stop_reason` to `LLM::Message`
- Add `stop_reason` to Anthropic, Gemini, OpenAI and Ollama