### PR TITLE
feat(skills): add LLM::Skill

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,5 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 Style/ParenthesesAroundCondition:
   Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changes since `v4.20.2`.
   `acts_as_agent`, so models can wrap `LLM::Agent` with built-in
   persistence.
 
+* **Load directory-backed skills through `LLM::Context` and `LLM::Agent`** <br>
+  Add `skills:` to `LLM::Context` and `skills ...` to `LLM::Agent` so
+  directories with `SKILL.md` can be loaded, resolved into tools, and run
+  through the normal llm.rb tool path.
+
 ## v4.20.2
 
 Changes since `v4.20.1`.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ backed up by research. Maybe it won't always be true, and that would be good new
 because it would mean the Ruby ecosystem is getting stronger.
 
 llm.rb is not just an API wrapper: it gives you one runtime for providers,
-contexts, agents, tools, MCP servers, streaming, schemas, files, and persisted
-state, so real systems can be built out of one coherent execution model instead
-of a pile of adapters.
+contexts, agents, tools, skills, MCP servers, streaming, schemas, files, and
+persisted state, so real systems can be built out of one coherent execution
+model instead of a pile of adapters.
 
 llm.rb is designed for Ruby, and although it works great in Rails, it is not tightly
 coupled to it. It runs on the standard library by default (zero dependencies),
@@ -137,6 +137,11 @@ same context object.
 - **Tools are explicit** <br>
   Run local tools, provider-native tools, and MCP tools through the same path
   with fewer special cases.
+- **Skills are just tools loaded from directories** <br>
+  Point llm.rb at directories with a `SKILL.md`, resolve named tools through
+  the registry, and run those skills through `LLM::Context` or `LLM::Agent`
+  without creating a second execution model. If you are familiar with skills
+  in Claude or Codex, llm.rb supports the same general idea.
 - **Providers are normalized, not flattened** <br>
   Share one API surface across providers without losing access to provider-
   specific capabilities where they matter.
@@ -176,6 +181,7 @@ same context object.
 - **Run Tools While Streaming** — overlap model output with tool latency
 - **Concurrent Execution** — threads, async tasks, and fibers
 - **Agents** — reusable assistants with tool auto-execution
+- **Skills** — directory-backed capabilities loaded from `SKILL.md`
 - **Structured Outputs** — JSON Schema-based responses
 - **Responses API** — stateful response workflows where providers support them
 - **MCP Support** — stdio and HTTP MCP clients with prompt and tool support
@@ -383,6 +389,23 @@ end
 llm = LLM.openai(key: ENV["KEY"])
 agent = ShellAgent.new(llm)
 puts agent.talk("What time is it on this system?").content
+```
+
+#### Skills
+
+This example uses [`LLM::Agent`](https://0x1eef.github.io/x/llm.rb/LLM/Agent.html) with directory-backed skills so `SKILL.md` capabilities run through the normal tool path. If you have used skills in Claude or Codex, this is the same kind of building block. <br> See the [deepdive (web)](https://0x1eef.github.io/x/llm.rb/file.deepdive.html) or [deepdive (markdown)](resources/deepdive.md) for more examples.
+
+```ruby
+require "llm"
+
+class Agent < LLM::Agent
+  model "gpt-5.4-mini"
+  instructions "You are a concise release assistant."
+  skills "./skills/release", "./skills/review"
+end
+
+llm = LLM.openai(key: ENV["KEY"])
+puts Agent.new(llm).talk("Use the review skill.").content
 ```
 
 #### MCP

--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -29,6 +29,7 @@ module LLM
   require_relative "llm/eventstream"
   require_relative "llm/eventhandler"
   require_relative "llm/tool"
+  require_relative "llm/skill"
   require_relative "llm/server_tool"
   require_relative "llm/mcp"
 

--- a/lib/llm/agent.rb
+++ b/lib/llm/agent.rb
@@ -60,6 +60,17 @@ module LLM
     end
 
     ##
+    # Set or get the default skills
+    # @param [Array<String>, nil] skills
+    #  One or more skill directories
+    # @return [Array<String>, nil]
+    #  Returns the current skills when no argument is provided
+    def self.skills(*skills)
+      return @skills if skills.empty?
+      @skills = skills.flatten
+    end
+
+    ##
     # Set or get the default schema
     # @param [#to_json, nil] schema
     #  The schema
@@ -110,10 +121,11 @@ module LLM
     #  not only those listed here.
     # @option params [String] :model Defaults to the provider's default model
     # @option params [Array<LLM::Function>, nil] :tools Defaults to nil
+    # @option params [Array<String>, nil] :skills Defaults to nil
     # @option params [#to_json, nil] :schema Defaults to nil
     # @option params [Symbol, Array<Symbol>, nil] :concurrency Defaults to the agent class concurrency
     def initialize(llm, params = {})
-      defaults = {model: self.class.model, tools: self.class.tools, schema: self.class.schema}.compact
+      defaults = {model: self.class.model, tools: self.class.tools, skills: self.class.skills, schema: self.class.schema}.compact
       @concurrency = params.delete(:concurrency) || self.class.concurrency
       @llm = llm
       @ctx = LLM::Context.new(llm, defaults.merge(params))

--- a/lib/llm/context.rb
+++ b/lib/llm/context.rb
@@ -64,10 +64,13 @@ module LLM
     # @option params [Symbol] :mode Defaults to :completions
     # @option params [String] :model Defaults to the provider's default model
     # @option params [Array<LLM::Function>, nil] :tools Defaults to nil
+    # @option params [Array<String>, nil] :skills Defaults to nil
     def initialize(llm, params = {})
       @llm = llm
       @mode = params.delete(:mode) || :completions
+      tools = [*params.delete(:tools), *load_skills(params.delete(:skills))]
       @params = {model: llm.default_model, schema: nil}.compact.merge!(params)
+      @params[:tools] = tools unless tools.empty?
       @messages = LLM::Buffer.new(llm)
     end
 
@@ -344,6 +347,10 @@ module LLM
       return unless LLM::Stream === stream
       stream.extra[:tracer] = tracer
       stream.extra[:model] = model
+    end
+
+    def load_skills(skills)
+      [*skills].map { LLM::Skill.load(_1).to_tool(llm) }
     end
   end
 

--- a/lib/llm/skill.rb
+++ b/lib/llm/skill.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module LLM
+  ##
+  # {LLM::Skill LLM::Skill} represents a directory-backed packaged capability.
+  # A skill directory must contain a `SKILL.md` file with YAML frontmatter.
+  # Skills can expose themselves as normal {LLM::Tool LLM::Tool} classes through
+  # {#to_tool}. This keeps skills on the same execution path as local tools.
+  class Skill
+    ##
+    # Load a skill from a directory.
+    # @param [String, Pathname] path
+    # @return [LLM::Skill]
+    def self.load(path)
+      new(path).tap(&:load!)
+    end
+
+    ##
+    # Returns the skill directory.
+    # @return [String]
+    attr_reader :path
+
+    ##
+    # Returns the skill name.
+    # @return [String]
+    attr_reader :name
+
+    ##
+    # Returns the skill description.
+    # @return [String]
+    attr_reader :description
+
+    ##
+    # Returns the skill instructions.
+    # @return [String]
+    attr_reader :instructions
+
+    ##
+    # Returns the skill frontmatter.
+    # @return [LLM::Object]
+    attr_reader :frontmatter
+
+    ##
+    # Returns the skill tools.
+    # @return [Array<Class<LLM::Tool>>]
+    attr_reader :tools
+
+    def initialize(path)
+      @path = path.to_s
+      @name = ::File.basename(@path)
+      @description = "Skill: #{@name}"
+      @instructions = ""
+      @frontmatter = LLM::Object.from({})
+      @tools = []
+    end
+
+    ##
+    # Load and parse the skill.
+    # @return [LLM::Skill]
+    def load!
+      path = ::File.join(@path, "SKILL.md")
+      parse(::File.read(path))
+      self
+    end
+
+    ##
+    # Execute the skill by wrapping it in a small agent with the skill
+    # instructions. The provider is bound explicitly by the caller.
+    # @param [LLM::Provider] llm
+    # @param [Hash] input
+    # @return [Hash]
+    def call(llm, **)
+      instructions = self.instructions
+      tools = self.tools
+      agent = Class.new(LLM::Agent) do
+        instructions instructions
+        tools(*tools)
+      end.new(llm)
+      res = agent.talk(instructions)
+      {content: res.content}
+    end
+
+    ##
+    # Expose the skill as a normal LLM::Tool. The provider is bound explicitly
+    # when the tool class is built.
+    # @param [LLM::Provider] llm
+    # @return [Class<LLM::Tool>]
+    def to_tool(llm)
+      skill = self
+      Class.new(LLM::Tool) do
+        name skill.name
+        description skill.description
+
+        define_method(:call) do |**input|
+          skill.call(llm, **input)
+        end
+      end
+    end
+
+    private
+
+    def parse(content)
+      match = content.match(/\A---\s*\n(.*?)\n---\s*\n?(.*)\z/m)
+      unless match
+        @instructions = content
+        return
+      end
+      require "yaml" unless defined?(::YAML)
+      @frontmatter = LLM::Object.from(YAML.safe_load(match[1]) || {})
+      @name = @frontmatter.name || @name
+      @description = @frontmatter.description || @description
+      @tools = [*@frontmatter.tools].map { LLM::Tool.find_by_name!(_1) }
+      @instructions = match[2]
+    end
+  end
+end

--- a/resources/deepdive.md
+++ b/resources/deepdive.md
@@ -44,6 +44,7 @@ Most features extend these, rather than introducing new abstractions.
   - [Closure-Based Tools](#closure-based-tools)
   - [Concurrent Tools](#concurrent-tools)
 - [Agents](#agents)
+- [Skills](#skills)
 - [MCP](#mcp)
   - [MCP Tools Over Stdio](#mcp-tools-over-stdio)
   - [MCP Tools Over HTTP](#mcp-tools-over-http)
@@ -893,6 +894,39 @@ llm = LLM.openai(key: ENV["KEY"])
 agent = SystemAdmin.new(llm)
 res = agent.talk("Run 'date' and summarize the result.")
 puts res.content
+```
+
+## Skills
+
+[`LLM::Skill`](https://0x1eef.github.io/x/llm.rb/LLM/Skill.html) lets you
+package a capability as a directory with a `SKILL.md` file and then run that
+capability through the normal llm.rb tool path. Frontmatter can define `name`,
+`description`, and `tools`, where `tools` are resolved by name through the
+tool registry. [`LLM::Agent`](https://0x1eef.github.io/x/llm.rb/LLM/Agent.html)
+can declare skills with `skills ...`, and
+[`LLM::Context`](https://0x1eef.github.io/x/llm.rb/LLM/Context.html) also
+accepts `skills:` directly when you want lower-level control. If you are
+familiar with skills in Claude or Codex, llm.rb supports the same general
+pattern.
+
+```ruby
+#!/usr/bin/env ruby
+require "llm"
+
+class SearchDocs < LLM::Tool
+  name "search_docs"
+  description "Search the docs"
+  def call(**) = {results: ["..."]}
+end
+
+llm = LLM.openai(key: ENV["KEY"])
+class Agent < LLM::Agent
+  model "gpt-5.4-mini"
+  instructions "You are a concise release assistant."
+  skills "./skills/release"
+end
+
+puts Agent.new(llm).talk("Use the release skill.").content
 ```
 
 ## MCP

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe LLM::Agent do
         ).and_call_original
         expect(klass.new(provider).concurrency).to eq(:thread)
       end
+
+      it "passes DSL skills to the context" do
+        skill_path = "/tmp/weather"
+        skill = double("skill", to_tool: tool)
+        klass = Class.new(described_class) do
+          model "gpt-4.1"
+          skills skill_path
+        end
+        expect(LLM::Skill).to receive(:load).with(skill_path).and_return(skill)
+        expect(LLM::Context).to receive(:new).with(
+          provider,
+          {model: "gpt-4.1", tools: [], skills: [skill_path]}
+        ).and_call_original
+        klass.new(provider)
+      end
     end
 
     describe "#talk" do

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe LLM::Context do
     end
   end
 
+  context "when configured with skills" do
+    let(:provider) { LLM.openai(key: "test") }
+    let(:model) { "gpt-5.4" }
+    let(:skill_path) { "/tmp/weather" }
+    let(:tool) { double("tool") }
+    let(:skill) { double("skill", to_tool: tool) }
+
+    it "loads skills into tools" do
+      expect(LLM::Skill).to receive(:load).with(skill_path).and_return(skill)
+      ctx = described_class.new(provider, model:, skills: [skill_path])
+      expect(ctx.instance_variable_get(:@params)[:tools]).to eq([tool])
+    end
+  end
+
   context "when serializing tagged prompt objects" do
     let(:provider) { LLM.openai(key: "test") }
     let(:model) { "gpt-5.4" }

--- a/spec/llm/skill_spec.rb
+++ b/spec/llm/skill_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative "../setup"
+require "tmpdir"
+
+RSpec.describe LLM::Skill do
+  class WeatherTool < LLM::Tool
+    name "weather"
+    description "Get the current weather"
+
+    def call(**)
+      {content: "sunny"}
+    end
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @dir = dir
+      example.run
+    end
+  end
+
+  before do
+    LLM::Tool.clear_registry!
+    LLM::Tool.register(WeatherTool)
+  end
+
+  let(:skill_dir) { File.join(@dir, "weather") }
+  let(:provider) { double("provider", default_model: "gpt-5.4-mini") }
+
+  def write(path, content)
+    full = File.join(skill_dir, path)
+    FileUtils.mkdir_p(File.dirname(full))
+    File.write(full, content)
+  end
+
+  describe ".load" do
+    before do
+      write("SKILL.md", <<~MD)
+        ---
+        name: weather
+        description: Get the current weather
+        ---
+        Use the helper tools to answer the user's question.
+      MD
+    end
+
+    subject(:skill) { described_class.load(skill_dir) }
+
+    it "loads metadata from SKILL.md" do
+      expect(skill.name).to eq("weather")
+      expect(skill.description).to eq("Get the current weather")
+      expect(skill.frontmatter.name).to eq("weather")
+      expect(skill.frontmatter.description).to eq("Get the current weather")
+    end
+
+    it "exposes the instructions body" do
+      expect(skill.instructions).to include("Use the helper tools")
+    end
+
+    it "loads tools from SKILL.md" do
+      write("SKILL.md", <<~MD)
+        ---
+        name: weather
+        description: Get the current weather
+        tools:
+          - weather
+        ---
+        Use the helper tools to answer the user's question.
+      MD
+      expect(skill.tools).to eq([WeatherTool])
+    end
+
+    it "raises when a tool is missing" do
+      write("SKILL.md", <<~MD)
+        ---
+        tools:
+          - missing
+        ---
+        Use the helper tools to answer the user's question.
+      MD
+      expect { described_class.load(skill_dir) }.to raise_error(LLM::NoSuchToolError, /missing/)
+    end
+  end
+
+  describe "#to_tool" do
+    before do
+      write("SKILL.md", <<~MD)
+        ---
+        name: weather
+        description: Get the current weather
+        tools:
+          - weather
+        ---
+        Use the helper tools.
+      MD
+    end
+
+    let(:skill) { described_class.load(skill_dir) }
+    let(:tool) { skill.to_tool(provider) }
+
+    it "builds a tool with the skill metadata" do
+      expect(tool.name).to eq("weather")
+      expect(tool.description).to eq("Get the current weather")
+    end
+
+    it "binds tool execution back to the skill" do
+      expect(skill).to receive(:call).with(provider, location: "London").and_return({content: "rain"})
+      expect(tool.new.call(location: "London")).to eq({content: "rain"})
+    end
+  end
+
+  describe "#call" do
+    before do
+      write("SKILL.md", <<~MD)
+        ---
+        name: weather
+        description: Get the current weather
+        ---
+        Use the helper tools.
+      MD
+    end
+
+    let(:skill) { described_class.load(skill_dir) }
+    let(:response) { double("response", content: "It is raining") }
+
+    it "uses an internal agent and returns tool-shaped output" do
+      allow_any_instance_of(LLM::Agent).to receive(:talk).with("Use the helper tools.\n").and_return(response)
+      expect(skill.call(provider, location: "London")).to eq({content: "It is raining"})
+    end
+  end
+end


### PR DESCRIPTION
## About

Add LLM::Skill as a small directory-backed capability 
that loads SKILL.md, resolves named tools, and plugs 
into the existing LLM::Context and LLM::Agent tool paths.

## Changes

- Add LLM::Skill and wire skills: into LLM::Context.
- Add skills ... support to LLM::Agent.
- Document skills in the README, deep dive, and changelog.
- Add focused specs for skill loading, tool lookup, and execution.