### PR TITLE
Fix README logo link target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="llm.rb">
+  <a href="https://github.com/llmrb/llm.rb">
     <img src="https://github.com/llmrb/llm.rb/raw/main/llm.png" width="200" height="200" border="0" alt="llm.rb">
   </a>
 </p>


### PR DESCRIPTION
The README logo currently links to the relative path `llm.rb`, which renders as a non-existent path in the repository. This updates the logo link to the repository URL so clicking it stays on a valid destination.