### PR TITLE
repl: add bin/llm.rb

### DIFF
--- a/bin/llm.rb
+++ b/bin/llm.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+
+require "llm"
+require "fileutils"
+
+##
+# utils
+
+def keys
+  @keys ||= Dir[File.join(__dir__, "..", "lib", "llm", "providers", "*")]
+    .select { File.file?(_1) }
+    .map { File.basename(_1, ".rb") }
+    .sort_by { _1 == "deepseek" ? 0 : 1 }
+    .map { "#{_1.upcase}_API_KEY" } - ["BEDROCK_API_KEY"]
+end
+
+def help
+  prog = File.basename($PROGRAM_NAME)
+  warn ""
+  warn "Usage: #{prog} [options]"
+  warn ""
+  warn "Options:"
+  warn "  -p PROVIDER    Choose a provider"
+  warn "  -t             Temporary session that doesn't persist to disk"
+  warn "  -h             Show this help"
+  warn ""
+  warn "Examples:"
+  warn "  #{prog}                     # auto-detect provider from $PROVIDER_API_KEY"
+  warn "  #{prog} -p openai           # use OpenAI"
+  warn "  #{prog} -h                  # this help"
+  warn ""
+end
+
+def loaderror(ex)
+  gem, = ex.message.split(" is an optional runtime dependency")
+  warn ""
+  warn "  ── llm.rb ──────────────────────────────────────────────"
+  warn ""
+  warn "  ✖  Missing dependency: #{gem}"
+  warn ""
+  warn "     The repl needs this gem, but it's not installed."
+  warn ""
+  warn "     Fix:  gem install #{gem}"
+  warn "     Or:   bundle add #{gem}"
+  warn ""
+  warn "     Tip:  If you don't need the repl, you can use the"
+  warn "           library directly with:  require \"llm\""
+  warn ""
+  warn "  ───────────────────────────────────────────────────────"
+  warn ""
+end
+
+##
+# main
+
+def main(argv)
+  ##
+  # Make sure the dependencies are satisified first
+  begin
+    require "llm/tools"
+    require "llm/repl"
+  rescue LLM::LoadError => ex
+    loaderror(ex)
+    exit 1
+  end
+
+  ##
+  # C-Style option parser
+  # No external dep
+  while option = argv.shift
+    case option
+    when '-h'
+      help
+      exit 0
+    when '-t'
+      temp = true
+    when '-p'
+      provider = argv.shift
+    else
+      warn "llm.rb: unknown option #{option}"
+    end
+  end
+
+  ##
+  # Setup the home directory
+  # But only if the `-t` switch has not been provided
+  if temp.nil?
+    home = File.join(Dir.home, ".llm.rb")
+    FileUtils.mkdir_p(File.join(home, Dir.getwd))
+    session = File.join(home, Dir.getwd, "session.json")
+  end
+
+  ##
+  # No provider has been given.
+  # Try to infer one.
+  if provider.nil?
+    key = keys.find { ENV[_1] }
+    if key.nil?
+      warn "llm.rb: provide a provider with the -p switch"
+      exit 1
+    else
+      provider, = key.split("_")
+    end
+  end
+
+  ##
+  # We're ready to start the REPL
+  # This should always succeed unless -p gave garbage
+  provider = provider.downcase
+  if LLM.respond_to?(provider)
+    key ||= "#{provider.upcase}_API_KEY"
+    if ENV[key].nil? || ENV[key].to_s.empty?
+      warn "llm.rb: set #{key} to use #{provider}"
+      exit 1
+    end
+    llm = LLM.method(provider).call(key: ENV[key])
+    agent = LLM::Agent.new(llm, path: temp ? nil : session, tools: LLM::Tool.subclasses)
+    agent.repl
+  else
+    warn "llm.rb: #{provider} was not recognized"
+    exit 1
+  end
+end
+main(ARGV)

--- a/lib/llm/agent.rb
+++ b/lib/llm/agent.rb
@@ -58,6 +58,11 @@ module LLM
     private_constant :CASE_PATTERN
 
     ##
+    # @api private
+    File = ::File
+    private_constant :File
+
+    ##
     # Returns a provider
     # @return [LLM::Provider]
     attr_reader :llm
@@ -338,7 +343,7 @@ module LLM
         end
       end
       @ctx = LLM::Context.new(llm, {guard: true}.merge(params))
-      @path ? @ctx.restore(path:) : nil
+      @path and File.readable?(@path) ? @ctx.restore(path:) : nil
     end
 
     ##


### PR DESCRIPTION
I use the llm.rb repl as my main interface to deepseek. 
I can't really afford codex or claude plus I prefer to use 
my own tools anyway.

The only downside is that everytime I want to start the repl 
I have to write an `agent.rb` script with five or so lines and 
repeating that over and over has become irritating.

So I decided to introduce an llm.rb executable that can start
the repl where ever i am.